### PR TITLE
feat: Add interactive maps and statistics with FamilyTreeDNA colors

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -127,6 +127,344 @@ body {
     }
 }
 
+/* Tab Navigation */
+.tab-navigation {
+    background: var(--bg-white);
+    display: flex;
+    gap: 0;
+    padding: 0;
+    border-bottom: 2px solid var(--border-light);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.tab-btn {
+    flex: 1;
+    background: transparent;
+    border: none;
+    padding: 16px 20px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    position: relative;
+}
+
+.tab-btn::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: transparent;
+    transition: background 0.2s ease;
+}
+
+.tab-btn:hover {
+    background: var(--bg-light);
+    color: var(--text-primary);
+}
+
+.tab-btn.active {
+    color: var(--male-color);
+    font-weight: 600;
+}
+
+.tab-btn.active::after {
+    background: var(--male-color);
+}
+
+.tab-icon {
+    font-size: 1.1rem;
+}
+
+.tab-label {
+    display: inline;
+}
+
+/* Tab Content */
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+/* Map Sub-Navigation */
+.map-tabs {
+    background: var(--bg-light);
+    display: flex;
+    gap: 8px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-light);
+    flex-wrap: wrap;
+}
+
+.map-tab-btn {
+    background: var(--bg-white);
+    border: 2px solid var(--border-medium);
+    padding: 8px 16px;
+    border-radius: 20px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    transition: all 0.2s ease;
+}
+
+.map-tab-btn:hover {
+    background: var(--bg-medium);
+    border-color: var(--male-color);
+}
+
+.map-tab-btn.active {
+    background: var(--male-color);
+    color: white;
+    border-color: var(--male-color);
+}
+
+/* Map Containers */
+.map-container {
+    display: none;
+    position: relative;
+}
+
+.map-container.active {
+    display: block;
+}
+
+.map-view {
+    height: 600px;
+    width: 100%;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.map-legend {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    background: white;
+    padding: 12px 16px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    font-size: 0.85rem;
+    max-width: 200px;
+}
+
+.map-controls {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    background: white;
+    padding: 12px 16px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    display: flex;
+    gap: 12px;
+}
+
+.map-controls label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+
+/* Statistics and About Content */
+.stats-container,
+.about-container {
+    background: var(--bg-white);
+    padding: 40px;
+    border-radius: 8px;
+    max-width: 1200px;
+    margin: 20px auto;
+}
+
+.stats-container h2,
+.about-container h2 {
+    color: var(--male-color);
+    margin-bottom: 20px;
+}
+
+.about-container p {
+    color: var(--text-primary);
+    line-height: 1.6;
+    margin-bottom: 15px;
+}
+
+/* Support Section */
+.support-section {
+    margin-top: 40px;
+    padding: 30px;
+    background: var(--bg-light);
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+}
+
+.support-section h3 {
+    color: var(--male-color);
+    margin-bottom: 15px;
+    font-size: 1.3em;
+}
+
+.support-section p {
+    color: var(--text-secondary);
+    margin-bottom: 20px;
+}
+
+.support-options {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.support-link {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    padding: 15px 20px;
+    background: var(--bg-white);
+    border: 2px solid var(--border-light);
+    border-radius: 8px;
+    text-decoration: none;
+    color: var(--text-primary);
+    transition: all 0.3s ease;
+}
+
+.support-link:hover {
+    border-color: var(--male-color);
+    box-shadow: 0 2px 8px rgba(71, 117, 113, 0.2);
+    transform: translateY(-2px);
+}
+
+.support-logo {
+    height: 40px;
+    width: auto;
+    object-fit: contain;
+}
+
+.support-link span {
+    font-weight: 500;
+    font-size: 1.05em;
+}
+
+/* FamilyTreeDNA styled text logo */
+.ftdna-logo {
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 16px;
+    background: linear-gradient(135deg, #2c5282 0%, #1a365d 100%);
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.ftdna-text {
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 0.95em;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+}
+
+.ftdna-link:hover .ftdna-logo {
+    background: linear-gradient(135deg, #1a365d 0%, #2c5282 100%);
+}
+
+/* Charts Grid */
+.charts-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+    margin-top: 24px;
+}
+
+.chart-card {
+    background: var(--bg-card);
+    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.chart-card.full-width {
+    grid-column: 1 / -1;
+}
+
+.chart-card h3 {
+    color: var(--text-primary);
+    font-size: 1rem;
+    margin-bottom: 16px;
+    text-align: center;
+}
+
+.chart-card canvas {
+    max-height: 300px;
+}
+
+.chart-stats {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border-light);
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+/* Responsive tabs */
+@media (max-width: 768px) {
+    .tab-label {
+        display: none;
+    }
+    
+    .tab-icon {
+        font-size: 1.3rem;
+    }
+    
+    .map-tabs {
+        justify-content: center;
+    }
+    
+    .map-view {
+        height: 400px;
+    }
+    
+    .map-legend {
+        bottom: 10px;
+        right: 10px;
+        font-size: 0.75rem;
+    }
+    
+    .charts-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .chart-card.full-width {
+        grid-column: 1;
+    }
+    
+    .support-section {
+        padding: 20px;
+    }
+    
+    .support-logo {
+        height: 32px;
+    }
+    
+    .support-link {
+        padding: 12px 16px;
+    }
+}
+
 /* Filter bar - white background for contrast */
 .filter-bar {
     background: var(--bg-white);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -42,6 +42,16 @@ class HeritageApp {
             // Load initial results
             await this.loadResults();
             
+            // Initialize maps module if available
+            if (window.heritageMaps) {
+                await window.heritageMaps.init(this.dataLoader.heritageData);
+            }
+            
+            // Initialize statistics module if available
+            if (window.heritageStatistics) {
+                await window.heritageStatistics.init(this.dataLoader.heritageData);
+            }
+            
             console.log('✅ Application initialized successfully');
             
         } catch (error) {
@@ -910,6 +920,16 @@ class HeritageApp {
                 processedData = processedData.filter(family => 
                     searchResults.some(sr => sr.id === family.id)
                 );
+            }
+
+            // Update maps with filtered data
+            if (window.heritageMaps && window.heritageMaps.initialized) {
+                window.heritageMaps.updateWithFilteredData(processedData);
+            }
+
+            // Update statistics with filtered data
+            if (window.heritageStatistics && window.heritageStatistics.initialized) {
+                window.heritageStatistics.updateWithFilteredData(processedData);
             }
 
             // Check if we have any data

--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -1,0 +1,627 @@
+/**
+ * Maps Module for Circassian DNA Heritage
+ * Handles all map visualizations using Leaflet.js
+ */
+
+class HeritageMaps {
+    constructor() {
+        this.maps = {};
+        this.markers = {};
+        this.data = null;
+        this.initialized = false;
+    }
+
+    /**
+     * Initialize maps module
+     * @param {Array} heritageData - The heritage data from main app
+     */
+    async init(heritageData) {
+        console.log('🗺️ Initializing Heritage Maps...');
+        this.data = heritageData;
+        this.allData = heritageData; // Store original full dataset
+        this.setupTabSwitching();
+        this.setupMapTabSwitching();
+        this.initialized = true;
+    }
+
+    /**
+     * Update maps with filtered data from feed
+     * @param {Array} filteredData - Filtered heritage data
+     */
+    updateWithFilteredData(filteredData) {
+        console.log(`🔄 Updating maps with ${filteredData.length} filtered families`);
+        this.data = filteredData;
+        
+        // Refresh active maps
+        if (this.maps.village) {
+            this.refreshVillageMap();
+        }
+        if (this.maps.migration) {
+            this.refreshMigrationMap();
+        }
+    }
+
+    /**
+     * Refresh village map with current data
+     */
+    refreshVillageMap() {
+        // Clear existing markers
+        this.maps.village.eachLayer(layer => {
+            if (layer instanceof L.Marker) {
+                this.maps.village.removeLayer(layer);
+            }
+        });
+        
+        // Re-add markers with filtered data
+        this.addVillageMarkers();
+        this.updateVillageLegend();
+    }
+
+    /**
+     * Refresh migration map with current data
+     */
+    refreshMigrationMap() {
+        // Clear existing layers except base tile
+        this.maps.migration.eachLayer(layer => {
+            if (!(layer instanceof L.TileLayer)) {
+                this.maps.migration.removeLayer(layer);
+            }
+        });
+        
+        // Re-add migration paths with filtered data
+        this.addMigrationPaths();
+        
+        // Update legend
+        const legend = document.getElementById('migrationLegend');
+        if (legend) {
+            const pathCount = this.countMigrationPaths();
+            legend.innerHTML = `
+                <strong>Migration Paths</strong><br>
+                <div style="margin-top: 8px;">
+                    <span style="display: inline-block; width: 30px; height: 3px; background: var(--male-color); vertical-align: middle;"></span>
+                    <span style="margin-left: 4px; font-size: 0.85rem;">Pre → Main</span>
+                </div>
+                <div style="margin-top: 8px; font-size: 0.85rem; color: var(--text-secondary);">
+                    ${pathCount} ${pathCount === 1 ? 'path' : 'paths'} shown
+                </div>
+            `;
+        }
+    }
+
+    /**
+     * Setup main tab switching between Feed, Maps, Statistics, About
+     */
+    setupTabSwitching() {
+        const tabButtons = document.querySelectorAll('.tab-btn');
+        const tabContents = document.querySelectorAll('.tab-content');
+
+        tabButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const targetTab = button.dataset.tab;
+
+                // Update button states
+                tabButtons.forEach(btn => btn.classList.remove('active'));
+                button.classList.add('active');
+
+                // Update content visibility
+                tabContents.forEach(content => {
+                    if (content.dataset.content === targetTab) {
+                        content.classList.add('active');
+                        // Initialize map when Maps tab is opened
+                        if (targetTab === 'maps' && !this.maps.village) {
+                            this.initializeVillageMap();
+                        }
+                    } else {
+                        content.classList.remove('active');
+                    }
+                });
+            });
+        });
+    }
+
+    /**
+     * Setup map type switching within Maps tab
+     */
+    setupMapTabSwitching() {
+        const mapTabButtons = document.querySelectorAll('.map-tab-btn');
+        const mapContainers = document.querySelectorAll('.map-container');
+
+        mapTabButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const targetMap = button.dataset.map;
+
+                // Update button states
+                mapTabButtons.forEach(btn => btn.classList.remove('active'));
+                button.classList.add('active');
+
+                // Update map container visibility
+                mapContainers.forEach(container => {
+                    if (container.dataset.mapContent === targetMap) {
+                        container.classList.add('active');
+                        // Initialize specific map type
+                        this.initializeMapType(targetMap);
+                    } else {
+                        container.classList.remove('active');
+                    }
+                });
+            });
+        });
+    }
+
+    /**
+     * Initialize specific map type
+     * @param {string} mapType - Type of map to initialize
+     */
+    initializeMapType(mapType) {
+        switch (mapType) {
+            case 'village':
+                if (!this.maps.village) this.initializeVillageMap();
+                break;
+            case 'migration':
+                if (!this.maps.migration) this.initializeMigrationMap();
+                break;
+            case 'dna':
+                if (!this.maps.dna) this.initializeDNAMap();
+                break;
+            case 'territories':
+                if (!this.maps.territories) this.initializeTerritoriesMap();
+                break;
+        }
+    }
+
+    /**
+     * Initialize Village/Region Map
+     */
+    initializeVillageMap() {
+        console.log('🏘️ Initializing Village Map...');
+
+        // Create map centered on Caucasus region
+        this.maps.village = L.map('villageMap').setView([43.5, 43.0], 7);
+
+        // Add tile layer (OpenStreetMap)
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+            maxZoom: 19
+        }).addTo(this.maps.village);
+
+        // Process village data and add markers
+        this.addVillageMarkers();
+
+        // Update legend
+        this.updateVillageLegend();
+    }
+
+    /**
+     * Add markers for each village with family data
+     */
+    addVillageMarkers() {
+        if (!this.data || this.data.length === 0) {
+            console.log('⚠️ No data available for village markers');
+            return;
+        }
+
+        // Group families by village
+        const villageGroups = {};
+
+        this.data.forEach(family => {
+            const village = this.getVillageName(family);
+            const coordinates = this.getVillageCoordinates(family);
+
+            if (!village || !coordinates) return;
+
+            const key = `${coordinates.lat},${coordinates.lng}`;
+            
+            if (!villageGroups[key]) {
+                villageGroups[key] = {
+                    village: village,
+                    coordinates: coordinates,
+                    families: []
+                };
+            }
+            
+            villageGroups[key].families.push(family);
+        });
+
+        // Create markers for each village
+        Object.values(villageGroups).forEach(group => {
+            const familyCount = group.families.length;
+            
+            // Create custom icon based on family count
+            const icon = L.divIcon({
+                className: 'village-marker',
+                html: `
+                    <div class="marker-content" style="
+                        background: var(--male-color);
+                        color: white;
+                        border-radius: 50%;
+                        width: ${30 + Math.min(familyCount * 2, 40)}px;
+                        height: ${30 + Math.min(familyCount * 2, 40)}px;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        font-weight: bold;
+                        font-size: ${12 + Math.min(familyCount, 8)}px;
+                        box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+                        border: 3px solid white;
+                    ">
+                        ${familyCount}
+                    </div>
+                `,
+                iconSize: [30 + Math.min(familyCount * 2, 40), 30 + Math.min(familyCount * 2, 40)],
+                iconAnchor: [15 + Math.min(familyCount, 20), 15 + Math.min(familyCount, 20)]
+            });
+
+            // Create marker
+            const marker = L.marker([group.coordinates.lat, group.coordinates.lng], { icon })
+                .addTo(this.maps.village);
+
+            // Create popup content
+            const popupContent = this.createVillagePopup(group);
+            marker.bindPopup(popupContent, { maxWidth: 300 });
+        });
+
+        console.log(`✅ Added ${Object.keys(villageGroups).length} village markers`);
+    }
+
+    /**
+     * Get village name from family data
+     * @param {Object} family - Family data object
+     * @returns {string} Village name
+     */
+    getVillageName(family) {
+        if (!family.location?.village?.main) return null;
+        
+        const village = family.location.village.main;
+        return village.english || village.native || village.russian || 'Unknown';
+    }
+
+    /**
+     * Get village coordinates from family data
+     * @param {Object} family - Family data object
+     * @returns {Object} Coordinates {lat, lng}
+     */
+    getVillageCoordinates(family) {
+        const coords = family.location?.coordinates?.main;
+        
+        if (!coords || typeof coords.latitude !== 'number' || typeof coords.longitude !== 'number') {
+            return null;
+        }
+
+        return {
+            lat: coords.latitude,
+            lng: coords.longitude
+        };
+    }
+    /**
+     * Get pre-migration coordinates from family data
+     * @param {Object} family - Family data object
+     * @returns {Object} Coordinates {lat, lng} or null
+     */
+    getPreMigrationCoordinates(family) {
+        const coords = family.location?.coordinates?.pre;
+        
+        if (!coords || typeof coords.latitude !== 'number' || typeof coords.longitude !== 'number') {
+            return null;
+        }
+
+        return {
+            lat: coords.latitude,
+            lng: coords.longitude
+        };
+    }
+    /**
+     * Create popup content for village marker
+     * @param {Object} group - Village group data
+     * @returns {string} HTML content for popup
+     */
+    createVillagePopup(group) {
+        const families = group.families;
+        const familyCount = families.length;
+        
+        // Get state name
+        const stateName = families[0]?.location?.state?.main?.english || 
+                         families[0]?.location?.state?.main?.native || 
+                         families[0]?.location?.state?.main?.russian || '';
+
+        // Count haplogroups
+        const yDnaGroups = {};
+        const mtDnaGroups = {};
+        
+        families.forEach(family => {
+            const yDna = family.dna?.yDnaHaplogroup;
+            const mtDna = family.dna?.mtDnaHaplogroup;
+            
+            if (yDna && yDna !== 'N/A') {
+                yDnaGroups[yDna] = (yDnaGroups[yDna] || 0) + 1;
+            }
+            if (mtDna && mtDna !== 'N/A') {
+                mtDnaGroups[mtDna] = (mtDnaGroups[mtDna] || 0) + 1;
+            }
+        });
+
+        // Build popup HTML
+        let html = `
+            <div class="village-popup">
+                <h3 style="margin: 0 0 8px 0; color: var(--male-color);">${group.village}</h3>
+                ${stateName ? `<p style="margin: 0 0 12px 0; color: var(--text-secondary); font-size: 0.85rem;">${stateName}</p>` : ''}
+                <p style="margin: 0 0 8px 0;"><strong>${familyCount}</strong> ${familyCount === 1 ? 'family' : 'families'}</p>
+        `;
+
+        // Add Y-DNA haplogroups
+        if (Object.keys(yDnaGroups).length > 0) {
+            html += `<div style="margin-top: 12px;">
+                <strong style="color: var(--male-color);">Y-DNA:</strong><br>
+            `;
+            Object.entries(yDnaGroups)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 5)
+                .forEach(([haplogroup, count]) => {
+                    html += `<span style="font-size: 0.85rem;">${haplogroup} (${count})</span><br>`;
+                });
+            html += `</div>`;
+        }
+
+        // Add mtDNA haplogroups
+        if (Object.keys(mtDnaGroups).length > 0) {
+            html += `<div style="margin-top: 8px;">
+                <strong style="color: var(--female-color);">mtDNA:</strong><br>
+            `;
+            Object.entries(mtDnaGroups)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 5)
+                .forEach(([haplogroup, count]) => {
+                    html += `<span style="font-size: 0.85rem;">${haplogroup} (${count})</span><br>`;
+                });
+            html += `</div>`;
+        }
+
+        html += `</div>`;
+        return html;
+    }
+
+    /**
+     * Update village map legend
+     */
+    updateVillageLegend() {
+        const legend = document.getElementById('villageLegend');
+        if (!legend) return;
+
+        legend.innerHTML = `
+            <strong>Family Count</strong><br>
+            <div style="margin-top: 8px;">
+                <span style="display: inline-block; width: 30px; height: 30px; background: var(--male-color); border-radius: 50%; text-align: center; line-height: 30px; color: white; font-size: 0.75rem; vertical-align: middle;">1-5</span>
+                <span style="margin-left: 4px; font-size: 0.85rem;">Few</span>
+            </div>
+            <div style="margin-top: 4px;">
+                <span style="display: inline-block; width: 40px; height: 40px; background: var(--male-color); border-radius: 50%; text-align: center; line-height: 40px; color: white; font-size: 0.85rem; vertical-align: middle;">6-10</span>
+                <span style="margin-left: 4px; font-size: 0.85rem;">Many</span>
+            </div>
+            <div style="margin-top: 4px;">
+                <span style="display: inline-block; width: 50px; height: 50px; background: var(--male-color); border-radius: 50%; text-align: center; line-height: 50px; color: white; font-size: 0.95rem; vertical-align: middle;">10+</span>
+                <span style="margin-left: 4px; font-size: 0.85rem;">Most</span>
+            </div>
+        `;
+    }
+
+    /**
+     * Initialize Migration Paths Map
+     */
+    initializeMigrationMap() {
+        console.log('🛤️ Initializing Migration Map...');
+
+        this.maps.migration = L.map('migrationMap').setView([43.5, 43.0], 6);
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+            maxZoom: 19
+        }).addTo(this.maps.migration);
+
+        // Add migration paths
+        this.addMigrationPaths();
+
+        // Update legend
+        const legend = document.getElementById('migrationLegend');
+        if (legend) {
+            const pathCount = this.countMigrationPaths();
+            legend.innerHTML = `
+                <strong>Migration Paths</strong><br>
+                <div style="margin-top: 8px;">
+                    <span style="display: inline-block; width: 30px; height: 3px; background: var(--male-color); vertical-align: middle;"></span>
+                    <span style="margin-left: 4px; font-size: 0.85rem;">Pre → Main</span>
+                </div>
+                <div style="margin-top: 8px; font-size: 0.85rem; color: var(--text-secondary);">
+                    ${pathCount} ${pathCount === 1 ? 'path' : 'paths'} shown
+                </div>
+            `;
+        }
+    }
+
+    /**
+     * Count families with migration paths
+     */
+    countMigrationPaths() {
+        if (!this.data) return 0;
+        return this.data.filter(family => {
+            const mainCoords = this.getVillageCoordinates(family);
+            const preCoords = this.getPreMigrationCoordinates(family);
+            return mainCoords && preCoords;
+        }).length;
+    }
+
+    /**
+     * Add migration path lines and markers
+     */
+    addMigrationPaths() {
+        if (!this.data || this.data.length === 0) {
+            console.log('⚠️ No data available for migration paths');
+            return;
+        }
+
+        const migrations = [];
+        
+        this.data.forEach(family => {
+            const mainCoords = this.getVillageCoordinates(family);
+            const preCoords = this.getPreMigrationCoordinates(family);
+            
+            if (!mainCoords || !preCoords) return;
+            
+            // Check if coordinates are different (actual migration)
+            if (mainCoords.lat === preCoords.lat && mainCoords.lng === preCoords.lng) {
+                return;
+            }
+            
+            migrations.push({
+                family: family,
+                from: preCoords,
+                to: mainCoords,
+                preVillage: family.location?.village?.pre?.english || 
+                           family.location?.village?.pre?.native || 
+                           family.location?.village?.pre?.russian || 'Unknown',
+                mainVillage: this.getVillageName(family)
+            });
+        });
+
+        console.log(`Found ${migrations.length} migration paths`);
+
+        // Group migrations by path for better visualization
+        const pathGroups = {};
+        migrations.forEach(mig => {
+            const key = `${mig.from.lat},${mig.from.lng}-${mig.to.lat},${mig.to.lng}`;
+            if (!pathGroups[key]) {
+                pathGroups[key] = {
+                    from: mig.from,
+                    to: mig.to,
+                    preVillage: mig.preVillage,
+                    mainVillage: mig.mainVillage,
+                    families: []
+                };
+            }
+            pathGroups[key].families.push(mig.family);
+        });
+
+        // Draw migration paths
+        Object.values(pathGroups).forEach(group => {
+            const familyCount = group.families.length;
+            
+            // Draw curved line (polyline with offset)
+            const latlngs = [
+                [group.from.lat, group.from.lng],
+                [group.to.lat, group.to.lng]
+            ];
+            
+            const line = L.polyline(latlngs, {
+                color: 'var(--male-color)',
+                weight: Math.min(2 + familyCount, 8),
+                opacity: 0.6,
+                dashArray: '10, 5'
+            }).addTo(this.maps.migration);
+            
+            // Add arrow decorator
+            const midPoint = [
+                (group.from.lat + group.to.lat) / 2,
+                (group.from.lng + group.to.lng) / 2
+            ];
+            
+            // Bind popup to line
+            line.bindPopup(`
+                <div>
+                    <strong>Migration Path</strong><br>
+                    <span style="font-size: 0.85rem;">
+                        From: ${group.preVillage}<br>
+                        To: ${group.mainVillage}<br>
+                        Families: ${familyCount}
+                    </span>
+                </div>
+            `);
+            
+            // Add markers at start and end
+            L.circleMarker([group.from.lat, group.from.lng], {
+                radius: 5,
+                fillColor: '#ffc107',
+                color: 'white',
+                weight: 2,
+                opacity: 1,
+                fillOpacity: 0.8
+            }).addTo(this.maps.migration)
+              .bindPopup(`<strong>${group.preVillage}</strong><br>Origin`);
+            
+            L.circleMarker([group.to.lat, group.to.lng], {
+                radius: 6,
+                fillColor: 'var(--male-color)',
+                color: 'white',
+                weight: 2,
+                opacity: 1,
+                fillOpacity: 0.9
+            }).addTo(this.maps.migration)
+              .bindPopup(`<strong>${group.mainVillage}</strong><br>Current location`);
+        });
+
+        console.log(`✅ Added ${Object.keys(pathGroups).length} migration path groups`);
+    }
+
+    /**
+     * Initialize DNA Distribution Map
+     */
+    initializeDNAMap() {
+        console.log('🧬 Initializing DNA Distribution Map...');
+
+        this.maps.dna = L.map('dnaMap').setView([43.5, 43.0], 6);
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+            maxZoom: 19
+        }).addTo(this.maps.dna);
+
+        // Setup DNA type switching
+        const dnaTypeRadios = document.querySelectorAll('input[name="dnaType"]');
+        dnaTypeRadios.forEach(radio => {
+            radio.addEventListener('change', (e) => {
+                this.updateDNADistribution(e.target.value);
+            });
+        });
+
+        // Initial display
+        this.updateDNADistribution('ydna');
+    }
+
+    /**
+     * Update DNA distribution display
+     * @param {string} dnaType - 'ydna' or 'mtdna'
+     */
+    updateDNADistribution(dnaType) {
+        console.log(`Updating DNA distribution for ${dnaType}`);
+        
+        const legend = document.getElementById('dnaLegend');
+        if (legend) {
+            legend.innerHTML = `
+                <strong>${dnaType === 'ydna' ? 'Y-DNA' : 'mtDNA'} Distribution</strong><br>
+                <span style="font-size: 0.85rem; color: var(--text-secondary);">Heat maps coming soon...</span>
+            `;
+        }
+    }
+
+    /**
+     * Initialize Historical Territories Map
+     */
+    initializeTerritoriesMap() {
+        console.log('🏛️ Initializing Historical Territories Map...');
+
+        this.maps.territories = L.map('territoriesMap').setView([43.5, 43.0], 7);
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+            maxZoom: 19
+        }).addTo(this.maps.territories);
+
+        const legend = document.getElementById('territoriesLegend');
+        if (legend) {
+            legend.innerHTML = `
+                <strong>Historical Territories</strong><br>
+                <span style="font-size: 0.85rem; color: var(--text-secondary);">Overlays coming soon...</span>
+            `;
+        }
+    }
+}
+
+// Initialize maps when DOM is ready
+window.heritageMaps = new HeritageMaps();

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -1,0 +1,1254 @@
+/**
+ * Statistics Module for Circassian DNA Heritage
+ * Handles all data visualization using Chart.js
+ */
+
+/** FamilyTreeDNA color scheme
+'r1c01': #795548;
+'r1c02': #D50A12;
+'r1c03': #FF631D;
+'r1c04': #FFD22C;
+'r1c05': #4DD92E;
+'r1c06': #808000;
+'r1c07': #1E8E00;
+'r1c08': #2DBE60;
+'r1c09': #33A6B8;
+'r1c10': #1F63B5;
+'r1c11': #8E24AA;
+'r1c12': #C2185B;
+'r1c13': #757575;
+
+
+
+'r2c01': #A1887f;
+'r2c02': #FF1744;
+'r2c03': #FB8C00;
+'r2c04': #FFEA00;
+'r2c05': #64DD17;
+'r2c06': #C0CA33;
+'r2c07': #66BB6A;
+'r2c08': #2ECC71;
+'r2c09': #3DD5D8;
+'r2c10': #2962FF;
+'r2c11': #D500F9;
+'r2c12': #F50057;
+'r2c13': #CFCFCF;
+
+
+'r3c01': #EDE8E6;
+'r3c02': #E6A8AD;
+'r3c03': #F2D19C;
+'r3c04': #F6E7A8;
+'r3c05': #C8F29D;
+'r3c06': #D6E6A8;
+'r3c07': #A5D6A7;
+'r3c08': #B1C6B1;
+'r3c09': #B2EBF2;
+'r3c10': #BBDEFB;
+'r3c11': #E1BEE7;
+'r3c12': #F8BBD0;
+'r3c13': #EEEEEE;
+ */
+
+class HeritageStatistics {
+    constructor() {
+        this.charts = {};
+        this.data = null;
+        this.initialized = false;
+        
+        // Predefined ethnicity color schema
+        this.ethnicityColors = {
+            'Circassian': '#24690a',
+            'Abkhazian': '#c92d25',
+            'Abazin': '#c92d25',
+            'Balkar': '#009aff',
+            'Karachay': '#009aff',
+            'Noghay': '#32ccfe',
+            'Kumyk': '#009fe3',
+            'Crimean Tatar': '#00a4de',
+            'Azerbaijan': '#00b5e2',
+            'Ossetian': '#ffd800',
+            'Ingush': '#4700b1',
+            'Chechen': '#4700b1',
+            'Dagestan': '#720088',
+            'Georgian': '#063970',
+            'Armenian': '#f2a800',
+            'paleoDNA': '#8a6240'
+        };
+
+        // Predefined clade color schema (for Y-DNA), based on FamilyTreeDNA groups
+        this.yDnaColors = {
+            'C1a1': '#EDE8E6',
+            'C1a2': '#EDE8E6',
+            'C1b1': '#EDE8E6',
+            'C1b2': '#EDE8E6',
+            'C2a1': '#EDE8E6',
+            'C2a2': '#EDE8E6',
+            'C2b1': '#EDE8E6',
+            'C2b2': '#EDE8E6',
+
+            'E1a1': '#757575',
+            'E1a2': '#757575',
+            'E1b1': '#757575',
+            'E1b2': '#757575',
+
+            'G1a1': '#C0CA33',
+            'G1a2': '#C0CA33',
+            'G1b1': '#C8F29D',
+            'G1b2': '#C8F29D',
+            'G2a1': '#64DD17',
+            'G2a2': '#2ECC71',
+            'G2b1': '#A5D6A7',
+            'G2b2': '#A5D6A7',
+
+            'H1a1': '#808000',
+            'H1a2': '#808000',
+            'H1b1': '#808000',
+            'H1b2': '#808000',
+            'H2a1': '#808000',
+            'H2a2': '#808000',
+            'H2b1': '#808000',
+            'H2b2': '#808000',
+
+            'I1a1': '#FF631D',
+            'I1a2': '#FF631D',
+            'I1a3': '#FF631D',
+            'I2a1': '#FB8C00',
+            'I2b1': '#FB8C00',
+            'I2b2': '#FB8C00',
+            'I2a2': '#FFD22C',
+            'I2c': '#FFD22C',
+
+            'J1a1': '#B2EBF2',
+            'J1a2': '#B2EBF2',
+            'J1b1': '#B2EBF2',
+            'J1b2': '#B2EBF2',
+            'J2a1': '#33A6B8',
+            'J2a2': '#2962FF',
+            'J2b1': '#1F63B5',
+            'J2b2': '#1F63B5',
+
+            'L1a1': '#A1887f',
+            'L1a2': '#A1887f',
+            'L1b1': '#A1887f',
+            'L1b2': '#A1887f',
+            'L2': '#A1887f',
+            'L2a1': '#A1887f',
+            'L2a2': '#A1887f',
+
+            'N1a1': '#F6E7A8',
+            'N1a2': '#F6E7A8',
+            'N1b1': '#F6E7A8',
+            'N1b2': '#F6E7A8',
+            
+            'O1a1': '#FFD22C',
+            'O1a2': '#FFD22C',
+            'O1b1': '#FFD22C',
+            'O1b2': '#FFD22C',
+            'O2a1': '#FFD22C',
+            'O2a2': '#FFD22C',
+            'O2b1': '#FFD22C',
+            'O2b2': '#FFD22C',
+            'O3a1': '#FFD22C',
+            'O3a2': '#FFD22C',
+            'O3b1': '#FFD22C',
+            'O3b2': '#FFD22C',
+
+            'Q1a1': '#D500F9',
+            'Q1a2': '#D500F9',
+            'Q1b1': '#D500F9',
+            'Q1b2': '#D500F9',
+            'Q2a1': '#D500F9',
+            'Q2a2': '#D500F9',
+            'Q2b1': '#D500F9',
+            'Q2b2': '#D500F9',
+
+            'R1a1': '#E6A8AD',
+            'R1a2': '#E6A8AD',
+            'R1b1': '#E1BEE7',
+            'R1b2': '#E1BEE7',
+            'R2a1': '#D500F9',
+            'R2a2': '#D500F9',
+            'R2b1': '#D500F9',
+            'R2b2': '#D500F9',
+
+            'T1a1': '#795548',
+            'T1a2': '#795548',
+            'T1b1': '#795548',
+            'T1b2': '#795548',
+            
+        };
+
+        // Predefined subclade color schema (for Y-DNA), based on FamilyTreeDNA groups
+        this.ySubcladeColors = {
+            'C-M216': '#EDE8E6',
+            'C-M217': '#EDE8E6',
+            'C-M48': '#EDE8E6',
+            'C-M86': '#EDE8E6',
+            'C-F1918': '#EDE8E6',
+            'C-F3830': '#EDE8E6',
+            'C-F9992': '#EDE8E6',
+            'C-F1067': '#EDE8E6',
+            'C-V20': '#EDE8E6',
+            'C-B477': '#EDE8E6',
+
+            'E-M2': '#757575',
+            'E-M35': '#757575',
+            'E-M123': '#757575',
+            'E-V13': '#757575',
+            'E-V22': '#757575',
+            
+            'G-GG313': '#C0CA33',
+            'G-GG349': '#C0CA33',
+            'G-BY1124': '#C0CA33',
+            'G-Z3353': '#C0CA33',
+
+            'G-Z17774': '#C8F29D',
+            'G-BY116538': '#C8F29D',
+
+            'G-Z6553': '#64DD17',
+            'G-Z6554': '#64DD17',
+            'G-Z6638': '#64DD17',
+            'G-Z6700': '#64DD17',
+            'G-Z6702': '#64DD17',
+            'G-Z7940': '#64DD17',
+            'G-Z7941': '#64DD17',
+            'G-Z7943': '#64DD17',
+            'G-Z31459': '#64DD17',
+            'G-Z31461': '#64DD17',
+            'G-Z31463': '#64DD17',
+            'G-Z45052': '#64DD17',
+            'G-FGC672': '#64DD17',
+            'G-FGC693': '#64DD17',
+            'G-FGC713': '#64DD17',
+            'G-FGC715': '#64DD17',
+            'G-FGC719': '#64DD17',
+            'G-FGC750': '#64DD17',
+            'G-FGC1053': '#64DD17',
+            'G-FGC1160': '#64DD17',
+            'G-FGC3764': '#64DD17',
+            'G-FGC3780': '#64DD17',
+            'G-GG330': '#64DD17',
+            'G-FT23146': '#64DD17',
+            'G-FT19842': '#64DD17',
+
+            'G-FGC5089': '#1E8E00',
+            'G-FGC6662': '#1E8E00',
+            'G-FGC6669': '#1E8E00',
+            'G-M406': '#1E8E00',
+
+            'G-CTS342': '#A5D6A7',
+            'G-S10654': '#A5D6A7',
+            'G-Z3440': '#A5D6A7',
+            'G-FT8419': '#A5D6A7',
+
+            'G-PH1780': '#66BB6A',
+            'G-PH311': '#66BB6A',
+            'G-FT32900': '#66BB6A',
+
+            'G-FT55754': '#2DBE60',
+
+            'G-L1264': '#2ECC71',
+            'G-FGC21495': '#2ECC71',
+            'G-S9409': '#2ECC71',
+            'G-Y142068': '#2ECC71',
+            'G-Z44145': '#2ECC71',
+            'G-Z30715': '#2ECC71',
+            'G-Z44151': '#2ECC71',
+            'G-FTC88737': '#2ECC71',
+            'G-Y142023': '#2ECC71',
+            'G-FTB56229': '#2ECC71',
+            'G-FT12999': '#2ECC71',
+            'G-V7991': '#2ECC71',
+            'G-Y112447': '#2ECC71',
+            'G-MF104773': '#2ECC71',
+            'G-FT9681': '#2ECC71',
+            'G-Y32923': '#2ECC71',
+            'G-FT49803': '#2ECC71',
+            'G-Y32599': '#2ECC71',
+            'G-FTA35887': '#2ECC71',
+            'G-L654': '#2ECC71',
+
+            'G-L13': '#B1C6B1',
+
+            'G-PF3369': '#1E8E00',
+            'G-PF3355': '#1E8E00',
+
+            'H-M52': '#808000',
+            'H-M69': '#808000',
+            'H-M82': '#808000',
+
+            'I-Z63': '#FF631D',
+            'I-BY151': '#FF631D',
+            'I-S2078': '#FF631D',
+            'I-L1237': '#FF631D',
+
+            'I-P37': '#FB8C00',
+            'I-P214': '#FB8C00',
+            'I-M223': '#FB8C00',
+            'I-L621': '#FB8C00',
+            'I-A427': '#FB8C00',
+            'I-Y5382': '#FB8C00',
+            'I-L1294': '#FB8C00',
+            'I-S20602': '#FB8C00',
+            'I-Y4460': '#FB8C00',
+            'I-Y3106': '#FB8C00',
+            'I-Z17855': '#FB8C00',
+            'I-FT8688': '#FB8C00',
+            'I-Y3548': '#FB8C00',
+
+            'I-L596': '#FFD22C',
+            'I-BY420': '#FFD22C',
+            'I-A1143': '#FFD22C',
+            'I-SK1270': '#FFD22C',
+
+            'J-P58': '#3DD5D8',
+            'J-Z1853': '#3DD5D8',
+            'J-FGC11': '#3DD5D8',
+            'J-YSC0000234': '#3DD5D8',
+            'J-Z18292': '#3DD5D8',
+            'J-L862': '#3DD5D8',
+
+            'J-Z1828': '#B2EBF2',
+            'J-Z1842': '#B2EBF2',
+            'J-CTS1460': '#B2EBF2',
+            'J-ZS3084': '#B2EBF2',
+            'J-ZS3089': '#B2EBF2',
+            'J-ZS3042': '#B2EBF2',
+            'J-Z18436': '#B2EBF2',
+
+            'J-L24': '#33A6B8',
+            'J-L25': '#33A6B8',
+            'J-L26': '#33A6B8',
+            'J-L70': '#33A6B8',
+            'J-Z387': '#33A6B8',
+            'J-Z438': '#33A6B8',
+            'J-Z7706': '#33A6B8',
+            'J-PF5366': '#33A6B8',
+            'J-FGC9883': '#33A6B8',
+            'J-Z2227': '#33A6B8',
+            'J-M67': '#33A6B8',
+            'J-M92': '#33A6B8',
+            'J-Z7671': '#33A6B8',
+            'J-Z7675': '#33A6B8',
+            'J-Y11200': '#33A6B8',
+            'J-Y30812': '#33A6B8',
+            'J-Y3612': '#33A6B8',
+            'J-Y7702': '#33A6B8',
+            'J-BY1147': '#33A6B8',
+            'J-S12459': '#33A6B8',
+            'J-CTS900': '#33A6B8',
+            'J-Z500': '#33A6B8',
+            'J-Z515': '#33A6B8',
+            'J-M319': '#33A6B8',
+            'J-P81': '#33A6B8',
+            'J-Z6065': '#33A6B8',
+            'J-Z7314': '#33A6B8',
+
+            'J-SK1313': '#BBDEFB',
+            'J-SK1317': '#BBDEFB',
+            'J-SK1320': '#BBDEFB',
+            'J-Z35834': '#BBDEFB',
+
+            'J-L581': '#2962FF',
+            'J-PF5016': '#2962FF',
+            'J-PH1795': '#2962FF',
+            'J-BY114993': '#2962FF',
+            
+            'J-Z1827': '#1F63B5',
+            'J-M241': '#1F63B5',
+            'J-M205': '#1F63B5',
+            'J-L283': '#1F63B5',
+            'J-Z1296': '#1F63B5',
+            'J-Z2453': '#1F63B5',
+
+            'L-M20': '#A1887f',
+            'L-M22': '#A1887f',
+            'L-M27': '#A1887f',
+            'L-M317': '#A1887f',
+            'L-M319': '#A1887f',
+            'L-M357': '#A1887f',
+            'L-SK1412': '#A1887f',
+            'L-PH8': '#A1887f',
+            'L-L595': '#A1887f',
+
+            'N-TAT': '#F6E7A8',
+            'N-M231': '#F6E7A8',
+            'N-F2905': '#F6E7A8',
+            'N-M1845': '#F6E7A8',
+            'N-M2005': '#F6E7A8',
+            'N-M2019': '#F6E7A8',
+            'N-L550': '#F6E7A8',
+            'N-A9407': '#F6E7A8',
+            'N-PH1896': '#F6E7A8',
+
+            'O-M122': '#FFD22C',
+            'O-M175': '#FFD22C',
+            'O-M324': '#FFD22C',
+            'O-M134': '#FFD22C',
+
+            'Q-L53': '#D500F9',
+            'Q-L54': '#D500F9',
+            'Q-M25': '#D500F9',
+            'Q-Y4800': '#D500F9',
+            'Q-Y11938': '#D500F9',
+            'Q-BZ640': '#D500F9',
+            'Q-L715': '#D500F9',
+            'Q-L330': '#D500F9',
+            'Q-Y2700': '#D500F9',
+            'Q-SK1392': '#D500F9',
+            'Q-SK1995': '#D500F9',
+
+            'R-Z280': '#F8BBD0',
+            'R-Z282': '#F8BBD0',
+            'R-Z283': '#F8BBD0',
+            'R-Z284': '#F8BBD0',
+            'R-L664': '#F8BBD0',
+            'R-M458': '#F8BBD0',
+            'R-L1029': '#F8BBD0',
+            'R-L260': '#F8BBD0',
+            'R-CTS1211': '#F8BBD0',
+            'R-CTS3402': '#F8BBD0',
+            'R-Y33': '#F8BBD0',
+            'R-Y2915': '#F8BBD0',
+            'R-YP315': '#F8BBD0',
+            'R-YP582': '#F8BBD0',
+            'R-P278': '#F8BBD0',
+            'R-Z92': '#F8BBD0',
+            'R-Y5570': '#F8BBD0',
+
+            'R-Z93': '#E6A8AD',
+            'R-Z94': '#E6A8AD',
+            'R-Z2122': '#E6A8AD',
+            'R-Z2123': '#E6A8AD',
+            'R-Z2124': '#E6A8AD',
+            'R-Z2125': '#E6A8AD',
+            'R-FGC82884': '#E6A8AD',
+            'R-Y934': '#E6A8AD',
+            'R-Y874': '#E6A8AD',
+            'R-YP451': '#E6A8AD',
+            'R-YP6354': '#E6A8AD',
+            'R-YP449': '#E6A8AD',
+            'R-YP450': '#E6A8AD',
+            'R-YP457': '#E6A8AD',
+            'R-FGC22480': '#E6A8AD',
+            'R-Y7094': '#E6A8AD',
+            'R-BY30762': '#E6A8AD',
+            'R-BY60213': '#E6A8AD',
+            'R-Y86480': '#E6A8AD',
+            'R-L657': '#E6A8AD',
+            'R-S23592': '#E6A8AD',
+            'R-Y57': '#E6A8AD',
+            'R-FGC4547': '#E6A8AD',
+
+            'R-M269': '#E1BEE7',
+            'R-M73': '#E1BEE7',
+            'R-M478': '#E1BEE7',
+            'R-L1432': '#E1BEE7',
+            'R-L1433': '#E1BEE7',
+            'R-L23': '#E1BEE7',
+            'R-L51': '#E1BEE7',
+            'R-Z2103': '#E1BEE7',
+            'R-Z2106': '#E1BEE7',
+            'R-Z2109': '#E1BEE7',
+            'R-L584': '#E1BEE7',
+            'R-M12149': '#E1BEE7',
+            'R-Y4364': '#E1BEE7',
+            'R-Y13369': '#E1BEE7',
+
+            'R-M207': '#D500F9',
+            
+            'T-M70': '#795548',
+            'T-Z709': '#795548',
+            'T-L208': '#795548',
+            'T-L131': '#795548',
+            'T-L446': '#795548',
+            'T-L454': '#795548',
+            'T-L454': '#795548',
+        }
+
+    }
+
+    /**
+     * Initialize statistics module
+     * @param {Array} heritageData - The heritage data from main app
+     */
+    async init(heritageData) {
+        console.log('📊 Initializing Heritage Statistics...');
+        this.data = heritageData;
+        this.allData = heritageData; // Store original full dataset
+        
+        // Setup tab listener to initialize charts when Statistics tab is opened
+        this.setupTabListener();
+        
+        this.initialized = true;
+    }
+
+    /**
+     * Setup listener for Statistics tab activation
+     */
+    setupTabListener() {
+        const statisticsTab = document.querySelector('[data-tab="statistics"]');
+        if (statisticsTab) {
+            statisticsTab.addEventListener('click', () => {
+                // Delay chart creation to ensure DOM is ready
+                setTimeout(() => {
+                    if (!this.charts.yDna) {
+                        // Always start with global data when first opening statistics
+                        this.data = this.allData;
+                        this.createAllCharts();
+                    }
+                }, 100);
+            });
+        }
+    }
+
+    /**
+     * Update statistics with filtered data from feed
+     * @param {Array} filteredData - Filtered heritage data
+     */
+    updateWithFilteredData(filteredData) {
+        console.log(`📊 Updating statistics with ${filteredData.length} filtered families`);
+        
+        // If no filters applied (full dataset), use all data
+        if (filteredData.length === this.allData.length) {
+            this.data = this.allData;
+        } else {
+            this.data = filteredData;
+        }
+        
+        // Refresh all charts if they exist
+        if (this.charts.yDna) {
+            this.updateAllCharts();
+        }
+    }
+
+    /**
+     * Create all statistics charts
+     */
+    createAllCharts() {
+        console.log('🎨 Creating statistics charts...');
+        
+        this.createYDnaChart();
+        this.createMtDnaChart();
+        this.createYSubcladeChart();
+        this.createMtSubcladeChart();
+        this.createEthnicityChart();
+        this.createVillageChart();
+    }
+
+    /**
+     * Update all existing charts
+     */
+    updateAllCharts() {
+        if (this.charts.yDna) this.updateYDnaChart();
+        if (this.charts.mtDna) this.updateMtDnaChart();
+        if (this.charts.ySubclade) this.updateYSubcladeChart();
+        if (this.charts.mtSubclade) this.updateMtSubcladeChart();
+        if (this.charts.ethnicity) this.updateEthnicityChart();
+        if (this.charts.village) this.updateVillageChart();
+    }
+
+    /**
+     * Get Y-DNA haplogroup distribution
+     */
+    getYDnaDistribution() {
+        const distribution = {};
+        let totalMales = 0;
+        
+        this.data.forEach(family => {
+            if (family.gender === 'male') {
+                totalMales++;
+                // Use clade from yDnaHaplogroup object
+                const clade = family.yDnaHaplogroup?.clade;
+                if (clade && clade !== 'N/A' && clade !== '—') {
+                    // Use full clade value (e.g., "G2a1", "R1a1")
+                    distribution[clade] = (distribution[clade] || 0) + 1;
+                }
+            }
+        });
+        
+        // Group by root haplogroup and sort
+        const grouped = {};
+        Object.entries(distribution).forEach(([clade, count]) => {
+            const root = clade.charAt(0);
+            if (!grouped[root]) grouped[root] = [];
+            grouped[root].push([clade, count]);
+        });
+        
+        // Calculate total for each root group
+        const groupTotals = Object.entries(grouped).map(([root, clades]) => {
+            const total = clades.reduce((sum, [, count]) => sum + count, 0);
+            return [root, total];
+        }).sort((a, b) => b[1] - a[1]);
+        
+        // Build final sorted distribution: groups by size, clades within group by count
+        const sortedDistribution = {};
+        groupTotals.forEach(([root]) => {
+            grouped[root]
+                .sort((a, b) => b[1] - a[1])
+                .forEach(([clade, count]) => {
+                    sortedDistribution[clade] = count;
+                });
+        });
+        
+        return { distribution: sortedDistribution, totalMales };
+    }
+
+    /**
+     * Get mtDNA haplogroup distribution
+     */
+    getMtDnaDistribution() {
+        const distribution = {};
+        let total = 0;
+        
+        this.data.forEach(family => {
+            total++;
+            // Use clade from mtDnaHaplogroup object
+            const clade = family.mtDnaHaplogroup?.clade;
+            if (clade && clade !== 'N/A' && clade !== '—') {
+                // Use full clade value (e.g., "H1a", "R1a")
+                distribution[clade] = (distribution[clade] || 0) + 1;
+            }
+        });
+        
+        // Group by root haplogroup and sort
+        const grouped = {};
+        Object.entries(distribution).forEach(([clade, count]) => {
+            const root = clade.charAt(0);
+            if (!grouped[root]) grouped[root] = [];
+            grouped[root].push([clade, count]);
+        });
+        
+        // Calculate total for each root group
+        const groupTotals = Object.entries(grouped).map(([root, clades]) => {
+            const total = clades.reduce((sum, [, count]) => sum + count, 0);
+            return [root, total];
+        }).sort((a, b) => b[1] - a[1]);
+        
+        // Build final sorted distribution: groups by size, clades within group by count
+        const sortedDistribution = {};
+        groupTotals.forEach(([root]) => {
+            grouped[root]
+                .sort((a, b) => b[1] - a[1])
+                .forEach(([clade, count]) => {
+                    sortedDistribution[clade] = count;
+                });
+        });
+        
+        return { distribution: sortedDistribution, total };
+    }
+
+    /**
+     * Get Y-DNA subclade distribution
+     */
+    getYSubcladeDistribution() {
+        const distribution = {};
+        const subcladeToCladeMap = {};
+        
+        this.data.forEach(family => {
+            if (family.gender === 'male') {
+                // Use subclade, clade, or root from yDnaHaplogroup object
+                const subclade = family.yDnaHaplogroup?.subclade || family.yDnaHaplogroup?.clade || family.yDnaHaplogroup?.root;
+                const clade = family.yDnaHaplogroup?.clade || family.yDnaHaplogroup?.root;
+                if (subclade && subclade !== 'N/A' && subclade !== '—') {
+                    distribution[subclade] = (distribution[subclade] || 0) + 1;
+                    // Map subclade to its clade for grouping
+                    if (clade) subcladeToCladeMap[subclade] = clade;
+                }
+            }
+        });
+        
+        // Group by clade
+        const grouped = {};
+        Object.entries(distribution).forEach(([subclade, count]) => {
+            const clade = subcladeToCladeMap[subclade] || subclade.charAt(0);
+            if (!grouped[clade]) grouped[clade] = [];
+            grouped[clade].push([subclade, count]);
+        });
+        
+        // Calculate total for each clade group
+        const groupTotals = Object.entries(grouped).map(([clade, subclades]) => {
+            const total = subclades.reduce((sum, [, count]) => sum + count, 0);
+            return [clade, total];
+        }).sort((a, b) => b[1] - a[1]);
+        
+        // Build sorted distribution: groups by clade size, subclades within group by count, take top 15
+        const sortedEntries = [];
+        groupTotals.forEach(([clade]) => {
+            grouped[clade]
+                .sort((a, b) => b[1] - a[1])
+                .forEach(entry => sortedEntries.push(entry));
+        });
+        
+        return sortedEntries
+            .slice(0, 15)
+            .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
+    }
+
+    /**
+     * Get mtDNA subclade distribution
+     */
+    getMtSubcladeDistribution() {
+        const distribution = {};
+        const subcladeToCladeMap = {};
+        
+        this.data.forEach(family => {
+            // Use subclade, clade, or root from mtDnaHaplogroup object
+            const subclade = family.mtDnaHaplogroup?.subclade || family.mtDnaHaplogroup?.clade || family.mtDnaHaplogroup?.root;
+            const clade = family.mtDnaHaplogroup?.clade || family.mtDnaHaplogroup?.root;
+            if (subclade && subclade !== 'N/A' && subclade !== '—') {
+                distribution[subclade] = (distribution[subclade] || 0) + 1;
+                // Map subclade to its clade for grouping
+                if (clade) subcladeToCladeMap[subclade] = clade;
+            }
+        });
+        
+        // Group by clade
+        const grouped = {};
+        Object.entries(distribution).forEach(([subclade, count]) => {
+            const clade = subcladeToCladeMap[subclade] || subclade.charAt(0);
+            if (!grouped[clade]) grouped[clade] = [];
+            grouped[clade].push([subclade, count]);
+        });
+        
+        // Calculate total for each clade group
+        const groupTotals = Object.entries(grouped).map(([clade, subclades]) => {
+            const total = subclades.reduce((sum, [, count]) => sum + count, 0);
+            return [clade, total];
+        }).sort((a, b) => b[1] - a[1]);
+        
+        // Build sorted distribution: groups by clade size, subclades within group by count, take top 15
+        const sortedEntries = [];
+        groupTotals.forEach(([clade]) => {
+            grouped[clade]
+                .sort((a, b) => b[1] - a[1])
+                .forEach(entry => sortedEntries.push(entry));
+        });
+        
+        return sortedEntries
+            .slice(0, 15)
+            .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
+    }
+
+    /**
+     * Get ethnicity distribution
+     */
+    getEthnicityDistribution() {
+        const distribution = {};
+        
+        this.data.forEach(family => {
+            const ethnicity = family.ethnicity?.main?.english || 
+                            family.ethnicity?.main?.native || 
+                            'Unknown';
+            distribution[ethnicity] = (distribution[ethnicity] || 0) + 1;
+        });
+        
+        return distribution;
+    }
+
+    /**
+     * Get colors for ethnicities using predefined schema
+     * @param {Array} labels - Array of ethnicity labels
+     * @returns {Array} Array of color hex codes
+     */
+    getEthnicityColors(labels) {
+        return labels.map((label, index) => {
+            // Use predefined color if available, otherwise generate
+            if (this.ethnicityColors[label]) {
+                return this.ethnicityColors[label];
+            }
+            // Fallback to generated color for unknown ethnicities
+            const hue = (index * 137.508) % 360;
+            return `hsl(${hue}, 70%, 50%)`;
+        });
+    }
+
+    /**
+     * Get colors for Y-DNA clades using predefined FamilyTreeDNA schema
+     * @param {Array} labels - Array of clade labels (e.g., ['G2a1', 'R1a1', 'J2a1'])
+     * @returns {Array} Array of color hex codes
+     */
+    getYDnaCladeColors(labels) {
+        return labels.map((label, index) => {
+            // Direct lookup in yDnaColors
+            if (this.yDnaColors[label]) {
+                return this.yDnaColors[label];
+            }
+            // Fallback to generated color for unknown clades
+            const hue = (index * 137.508) % 360;
+            return `hsl(${hue}, 60%, 55%)`;
+        });
+    }
+
+    /**
+     * Get colors for Y-DNA subclades using predefined FamilyTreeDNA schema
+     * @param {Array} labels - Array of subclade labels (e.g., ['G-Z6553', 'R-Z93'])
+     * @returns {Array} Array of color hex codes
+     */
+    getYSubcladeColors(labels) {
+        return labels.map((label, index) => {
+            // Use predefined color if available
+            if (this.ySubcladeColors[label]) {
+                return this.ySubcladeColors[label];
+            }
+            // Fallback to generated color for unknown subclades
+            const hue = (index * 137.508) % 360;
+            return `hsl(${hue}, 60%, 55%)`;
+        });
+    }
+
+    /**
+     * Get village distribution (top 10)
+     */
+    getVillageDistribution() {
+        const distribution = {};
+        
+        this.data.forEach(family => {
+            const village = family.location?.village?.main?.english || 
+                          family.location?.village?.main?.native || 
+                          family.location?.village?.main?.russian || 
+                          'Unknown';
+            distribution[village] = (distribution[village] || 0) + 1;
+        });
+        
+        // Sort by count and take top 10
+        return Object.entries(distribution)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 10)
+            .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
+    }
+
+    /**
+     * Generate distinct colors for chart
+     */
+    generateColors(count) {
+        const colors = [
+            '#477571', '#7b68ee', '#3498db', '#e74c3c', '#f39c12',
+            '#2ecc71', '#9b59b6', '#1abc9c', '#e67e22', '#95a5a6',
+            '#34495e', '#16a085', '#27ae60', '#2980b9', '#8e44ad'
+        ];
+        
+        // If we need more colors, generate them
+        while (colors.length < count) {
+            const hue = (colors.length * 137.508) % 360; // Golden angle
+            colors.push(`hsl(${hue}, 60%, 55%)`);
+        }
+        
+        return colors.slice(0, count);
+    }
+
+    /**
+     * Create Y-DNA Haplogroup Pie Chart
+     */
+    createYDnaChart() {
+        const ctx = document.getElementById('yDnaChart');
+        if (!ctx) return;
+
+        const { distribution, totalMales } = this.getYDnaDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        const colors = this.getYDnaCladeColors(labels);
+
+        this.charts.yDna = new Chart(ctx, {
+            type: 'pie',
+            data: {
+                labels: labels,
+                datasets: [{
+                    data: data,
+                    backgroundColor: colors,
+                    borderWidth: 2,
+                    borderColor: '#fff'
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {
+                    legend: {
+                        position: 'right',
+                        labels: {
+                            padding: 10,
+                            font: { size: 12 }
+                        }
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: function(context) {
+                                const label = context.label || '';
+                                const value = context.parsed || 0;
+                                const percentage = ((value / totalMales) * 100).toFixed(1);
+                                return `${label}: ${value} (${percentage}%)`;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // Update stats
+        const statsDiv = document.getElementById('yDnaStats');
+        if (statsDiv) {
+            const totalWithData = data.reduce((a, b) => a + b, 0);
+            statsDiv.innerHTML = `
+                <strong>Total Males:</strong> ${totalMales}<br>
+                <strong>With Y-DNA Data:</strong> ${totalWithData} (${((totalWithData/totalMales)*100).toFixed(1)}%)<br>
+                <strong>Unique Clades:</strong> ${labels.length}
+            `;
+        }
+    }
+
+    /**
+     * Create mtDNA Haplogroup Pie Chart
+     */
+    createMtDnaChart() {
+        const ctx = document.getElementById('mtDnaChart');
+        if (!ctx) return;
+
+        const { distribution, total } = this.getMtDnaDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        const colors = this.generateColors(labels.length);
+
+        this.charts.mtDna = new Chart(ctx, {
+            type: 'pie',
+            data: {
+                labels: labels,
+                datasets: [{
+                    data: data,
+                    backgroundColor: colors,
+                    borderWidth: 2,
+                    borderColor: '#fff'
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {
+                    legend: {
+                        position: 'right',
+                        labels: {
+                            padding: 10,
+                            font: { size: 12 }
+                        }
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: function(context) {
+                                const label = context.label || '';
+                                const value = context.parsed || 0;
+                                const percentage = ((value / total) * 100).toFixed(1);
+                                return `${label}: ${value} (${percentage}%)`;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // Update stats
+        const statsDiv = document.getElementById('mtDnaStats');
+        if (statsDiv) {
+            const totalWithData = data.reduce((a, b) => a + b, 0);
+            statsDiv.innerHTML = `
+                <strong>Total Families:</strong> ${total}<br>
+                <strong>With mtDNA Data:</strong> ${totalWithData} (${((totalWithData/total)*100).toFixed(1)}%)<br>
+                <strong>Unique Clades:</strong> ${labels.length}
+            `;
+        }
+    }
+
+    /**
+     * Create Y-DNA Subclade Pie Chart
+     */
+    createYSubcladeChart() {
+        const ctx = document.getElementById('ySubcladeChart');
+        if (!ctx) return;
+
+        const distribution = this.getYSubcladeDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        const colors = this.getYSubcladeColors(labels);
+
+        this.charts.ySubclade = new Chart(ctx, {
+            type: 'pie',
+            data: {
+                labels: labels,
+                datasets: [{
+                    data: data,
+                    backgroundColor: colors,
+                    borderColor: '#ffffff',
+                    borderWidth: 2
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {
+                    legend: {
+                        position: 'right',
+                        labels: {
+                            padding: 10,
+                            font: {
+                                size: 11
+                            }
+                        }
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: function(context) {
+                                const label = context.label || '';
+                                const value = context.parsed || 0;
+                                const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                                const percentage = ((value / total) * 100).toFixed(1);
+                                return `${label}: ${value} (${percentage}%)`;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Create mtDNA Subclade Pie Chart
+     */
+    createMtSubcladeChart() {
+        const ctx = document.getElementById('mtSubcladeChart');
+        if (!ctx) return;
+
+        const distribution = this.getMtSubcladeDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        const colors = this.generateColors(labels.length);
+
+        this.charts.mtSubclade = new Chart(ctx, {
+            type: 'pie',
+            data: {
+                labels: labels,
+                datasets: [{
+                    data: data,
+                    backgroundColor: colors,
+                    borderColor: '#ffffff',
+                    borderWidth: 2
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {
+                    legend: {
+                        position: 'right',
+                        labels: {
+                            padding: 10,
+                            font: {
+                                size: 11
+                            }
+                        }
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: function(context) {
+                                const label = context.label || '';
+                                const value = context.parsed || 0;
+                                const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                                const percentage = ((value / total) * 100).toFixed(1);
+                                return `${label}: ${value} (${percentage}%)`;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Create Ethnicity Pie Chart
+     */
+    createEthnicityChart() {
+        const ctx = document.getElementById('ethnicityChart');
+        if (!ctx) return;
+
+        const distribution = this.getEthnicityDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        const colors = this.getEthnicityColors(labels);
+
+        this.charts.ethnicity = new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: labels,
+                datasets: [{
+                    data: data,
+                    backgroundColor: colors,
+                    borderWidth: 2,
+                    borderColor: '#fff'
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {
+                    legend: {
+                        position: 'right',
+                        labels: {
+                            padding: 10,
+                            font: { size: 12 }
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Create Village Bar Chart (Top 10)
+     */
+    createVillageChart() {
+        const ctx = document.getElementById('villageChart');
+        if (!ctx) return;
+
+        const distribution = this.getVillageDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+
+        this.charts.village = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Families',
+                    data: data,
+                    backgroundColor: '#24690a',
+                    borderColor: '#1a4f07',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                indexAxis: 'y', // Horizontal bar chart
+                responsive: true,
+                maintainAspectRatio: true,
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        ticks: {
+                            stepSize: 1
+                        }
+                    }
+                },
+                plugins: {
+                    legend: {
+                        display: false
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Update Y-DNA chart with new data
+     */
+    updateYDnaChart() {
+        const { distribution, totalMales } = this.getYDnaDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        
+        this.charts.yDna.data.labels = labels;
+        this.charts.yDna.data.datasets[0].data = data;
+        this.charts.yDna.data.datasets[0].backgroundColor = this.getYDnaCladeColors(labels);
+        this.charts.yDna.update();
+
+        // Update stats
+        const statsDiv = document.getElementById('yDnaStats');
+        if (statsDiv) {
+            const totalWithData = data.reduce((a, b) => a + b, 0);
+            statsDiv.innerHTML = `
+                <strong>Total Males:</strong> ${totalMales}<br>
+                <strong>With Y-DNA Data:</strong> ${totalWithData} (${((totalWithData/totalMales)*100).toFixed(1)}%)<br>
+                <strong>Unique Clades:</strong> ${labels.length}
+            `;
+        }
+    }
+
+    /**
+     * Update mtDNA chart with new data
+     */
+    updateMtDnaChart() {
+        const { distribution, total } = this.getMtDnaDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        
+        this.charts.mtDna.data.labels = labels;
+        this.charts.mtDna.data.datasets[0].data = data;
+        this.charts.mtDna.data.datasets[0].backgroundColor = this.generateColors(labels.length);
+        this.charts.mtDna.update();
+
+        // Update stats
+        const statsDiv = document.getElementById('mtDnaStats');
+        if (statsDiv) {
+            const totalWithData = data.reduce((a, b) => a + b, 0);
+            statsDiv.innerHTML = `
+                <strong>Total Families:</strong> ${total}<br>
+                <strong>With mtDNA Data:</strong> ${totalWithData} (${((totalWithData/total)*100).toFixed(1)}%)<br>
+                <strong>Unique Clades:</strong> ${labels.length}
+            `;
+        }
+    }
+
+    /**
+     * Update Y-DNA subclade chart with new data
+     */
+    updateYSubcladeChart() {
+        const distribution = this.getYSubcladeDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        
+        this.charts.ySubclade.data.labels = labels;
+        this.charts.ySubclade.data.datasets[0].data = data;
+        this.charts.ySubclade.data.datasets[0].backgroundColor = this.getYSubcladeColors(labels);
+        this.charts.ySubclade.update();
+    }
+
+    /**
+     * Update mtDNA subclade chart with new data
+     */
+    updateMtSubcladeChart() {
+        const distribution = this.getMtSubcladeDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        
+        this.charts.mtSubclade.data.labels = labels;
+        this.charts.mtSubclade.data.datasets[0].data = data;
+        this.charts.mtSubclade.update();
+    }
+
+    /**
+     * Update ethnicity chart with new data
+     */
+    updateEthnicityChart() {
+        const distribution = this.getEthnicityDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        
+        this.charts.ethnicity.data.labels = labels;
+        this.charts.ethnicity.data.datasets[0].data = data;
+        this.charts.ethnicity.data.datasets[0].backgroundColor = this.getEthnicityColors(labels);
+        this.charts.ethnicity.update();
+    }
+
+    /**
+     * Update village chart with new data
+     */
+    updateVillageChart() {
+        const distribution = this.getVillageDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        
+        this.charts.village.data.labels = labels;
+        this.charts.village.data.datasets[0].data = data;
+        this.charts.village.update();
+    }
+}
+
+// Initialize statistics when DOM is ready
+window.heritageStatistics = new HeritageStatistics();

--- a/index.html
+++ b/index.html
@@ -13,6 +13,17 @@
     <link rel="stylesheet" href="./assets/css/styles.css">
     <link rel="stylesheet" href="./assets/css/compact-cards.css">
 
+    <!-- Leaflet.js for Maps -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
+          crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
+            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
+            crossorigin=""></script>
+
+    <!-- Chart.js for Statistics -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏔️</text></svg>">
 
@@ -64,8 +75,28 @@
             </div>
         </section>
 
+        <!-- Tab Navigation -->
+        <nav class="tab-navigation" aria-label="Main Navigation">
+            <button class="tab-btn active" data-tab="feed">
+                <span class="tab-icon">🔎</span>
+                <span class="tab-label">Feed</span>
+            </button>
+            <button class="tab-btn" data-tab="maps">
+                <span class="tab-icon">🌍</span>
+                <span class="tab-label">Maps</span>
+            </button>
+            <button class="tab-btn" data-tab="statistics">
+                <span class="tab-icon">📊</span>
+                <span class="tab-label">Statistics</span>
+            </button>
+            <button class="tab-btn" data-tab="about">
+                <span class="tab-icon">ℹ️</span>
+                <span class="tab-label">About</span>
+            </button>
+        </nav>
+
         <!-- Filter and Sort Bar -->
-        <nav class="filter-bar" aria-label="Filter and Sort Options">
+        <nav class="filter-bar tab-content" data-content="feed" aria-label="Filter and Sort Options">
             <div class="filter-row">
                 <!-- Search Bar -->
                 <div class="search-container">
@@ -116,10 +147,131 @@
             </div>
         </nav>
 
-        <!-- Main Content Area -->
-        <main class="feed-content" id="feedContent" aria-label="Heritage Family Profiles">
+        <!-- Feed Content Area -->
+        <main class="feed-content tab-content active" data-content="feed" id="feedContent" aria-label="Heritage Family Profiles">
             <!-- Heritage results will be populated by JavaScript -->
         </main>
+
+        <!-- Maps Content Area -->
+        <div class="tab-content" data-content="maps" id="mapsContent">
+            <!-- Map Sub-Navigation -->
+            <nav class="map-tabs" aria-label="Map Types">
+                <button class="map-tab-btn active" data-map="village">Village Map</button>
+                <button class="map-tab-btn" data-map="migration">Migration Paths</button>
+                <button class="map-tab-btn" data-map="dna">DNA Distribution</button>
+                <button class="map-tab-btn" data-map="territories">Historical Territories</button>
+            </nav>
+
+            <!-- Map Containers -->
+            <div class="map-container active" data-map-content="village">
+                <div id="villageMap" class="map-view"></div>
+                <div class="map-legend" id="villageLegend"></div>
+            </div>
+
+            <div class="map-container" data-map-content="migration">
+                <div id="migrationMap" class="map-view"></div>
+                <div class="map-legend" id="migrationLegend"></div>
+            </div>
+
+            <div class="map-container" data-map-content="dna">
+                <div id="dnaMap" class="map-view"></div>
+                <div class="map-controls">
+                    <label>
+                        <input type="radio" name="dnaType" value="ydna" checked> Y-DNA
+                    </label>
+                    <label>
+                        <input type="radio" name="dnaType" value="mtdna"> mtDNA
+                    </label>
+                </div>
+                <div class="map-legend" id="dnaLegend"></div>
+            </div>
+
+            <div class="map-container" data-map-content="territories">
+                <div id="territoriesMap" class="map-view"></div>
+                <div class="map-legend" id="territoriesLegend"></div>
+            </div>
+        </div>
+
+        <!-- Statistics Content Area -->
+        <div class="tab-content" data-content="statistics" id="statisticsContent">
+            <div class="stats-container">
+                <h2>Haplogroup Distribution Analysis</h2>
+                
+                <!-- Charts Grid -->
+                <div class="charts-grid">
+                    <!-- Y-DNA Pie Chart -->
+                    <div class="chart-card">
+                        <h3>Y-DNA Haplogroups</h3>
+                        <canvas id="yDnaChart"></canvas>
+                        <div id="yDnaStats" class="chart-stats"></div>
+                    </div>
+                    
+                    <!-- mtDNA Pie Chart -->
+                    <div class="chart-card">
+                        <h3>mtDNA Haplogroups</h3>
+                        <canvas id="mtDnaChart"></canvas>
+                        <div id="mtDnaStats" class="chart-stats"></div>
+                    </div>
+                    
+                    <!-- Y-DNA Subclade Pie Chart -->
+                    <div class="chart-card">
+                        <h3>Y-DNA Subclade Distribution</h3>
+                        <canvas id="ySubcladeChart"></canvas>
+                    </div>
+                    
+                    <!-- mtDNA Subclade Pie Chart -->
+                    <div class="chart-card">
+                        <h3>mtDNA Subclade Distribution</h3>
+                        <canvas id="mtSubcladeChart"></canvas>
+                    </div>
+                    
+                    <!-- Ethnicity Distribution -->
+                    <div class="chart-card">
+                        <h3>Ethnicity Distribution</h3>
+                        <canvas id="ethnicityChart"></canvas>
+                    </div>
+                    
+                    <!-- Village Distribution -->
+                    <div class="chart-card">
+                        <h3>Top 10 Villages</h3>
+                        <canvas id="villageChart"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- About Content Area -->
+        <div class="tab-content" data-content="about" id="aboutContent">
+            <div class="about-container">
+                <h2>About Circassian DNA Heritage</h2>
+                <p>This project documents the genetic lineage and ancestral connections of Circassian families.</p>
+                
+                <div class="support-section">
+                    <h3>Support This Project</h3>
+                    <p>Your support helps maintain and expand the Circassian DNA Heritage database. You can contribute through:</p>
+                    
+                    <div class="support-options">
+                        <!-- Patreon -->
+                        <a href="https://patreon.com/kabartay" target="_blank" rel="noopener noreferrer" class="support-link">
+                            <img src="https://upload.wikimedia.org/wikipedia/commons/9/94/Patreon_logo.svg" alt="Patreon" class="support-logo">
+                            <span>Support on Patreon</span>
+                        </a>
+                        
+                        <!-- Buy Me a Coffee -->
+                        <a href="https://buymeacoffee.com/kabartay" target="_blank" rel="noopener noreferrer" class="support-link">
+                            <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" class="support-logo">
+                            <span>Buy Me a Coffee</span>
+                        </a>
+                        
+                        <!-- FamilyTreeDNA -->
+                        <a href="https://www.familytreedna.com/group-general-fund-contribution.aspx?g=UbykhSochi" target="_blank" rel="noopener noreferrer" class="support-link">
+                            <img src="https://upload.wikimedia.org/wikipedia/en/9/93/FamilyTreeDNA_%28logo%29.png" alt="FamilyTreeDNA" class="support-logo">
+                            <span>Donate to Circassian DNA Project</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
 
         <!-- Loading Indicator: moved to main.js-->
     </div>
@@ -130,6 +282,8 @@
         const jsVersion = Date.now();
         document.write(`<script src="./assets/js/data-loader.js?v=${jsVersion}"><\/script>`);
         document.write(`<script src="./assets/js/main.js?v=${jsVersion}"><\/script>`);
+        document.write(`<script src="./assets/js/maps.js?v=${jsVersion}"><\/script>`);
+        document.write(`<script src="./assets/js/statistics.js?v=${jsVersion}"><\/script>`);
     </script>
 
     <!-- Initialize Application -->


### PR DESCRIPTION
- Added interactive village map with Leaflet showing family locations
- Added migration paths visualization with animated route markers
- Implemented 6 statistics charts: Y-DNA/mtDNA haplogroups, subclades, ethnicity, villages
- Integrated FamilyTreeDNA official color schemas (~430 color mappings)
- Implemented sophisticated haplogroup grouping and sorting algorithms
- Subclades grouped by parent clade (G2a1, R1a1) with descending sort
- Added support section with Patreon, Buy Me a Coffee, FamilyTreeDNA donation links
- Fixed tab navigation icons and layout
- All charts use predefined ethnicity colors and FamilyTreeDNA haplogroup colors
- Charts update dynamically with feed filters