### PR TITLE
fix: several bug fixes for infographics

### DIFF
--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -602,10 +602,10 @@ class DataLoader {
                           family.location?.village?.main?.english;
             if (village) villages.add(village);
             
-            // State (prefer native, fallback to russian, then english)
-            const state = family.location?.state?.main?.native || 
+            // State (prefer english, fallback to russian, then native)
+            const state = family.location?.state?.main?.english || 
                         family.location?.state?.main?.russian || 
-                        family.location?.state?.main?.english;
+                        family.location?.state?.main?.native;
             if (state) states.add(state);
             
             // Y-DNA Clade

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -544,9 +544,9 @@ class HeritageApp {
             const village = family.location?.village?.main?.native || 
                           family.location?.village?.main?.russian || 
                           family.location?.village?.main?.english;
-            const state = family.location?.state?.main?.native || 
+            const state = family.location?.state?.main?.english || 
                         family.location?.state?.main?.russian || 
-                        family.location?.state?.main?.english;
+                        family.location?.state?.main?.native;
             if (village && state) {
                 this.villageToStateMap[village] = state;
             }

--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -39,6 +39,12 @@ class HeritageMaps {
         if (this.maps.migration) {
             this.refreshMigrationMap();
         }
+        if (this.maps.ydna) {
+            this.updateDNADistribution('ydna', this.maps.ydna, 'ydnaLegend');
+        }
+        if (this.maps.mtdna) {
+            this.updateDNADistribution('mtdna', this.maps.mtdna, 'mtdnaLegend');
+        }
     }
 
     /**
@@ -611,9 +617,9 @@ class HeritageMaps {
     updateDNADistribution(dnaType, map, legendId) {
         console.log(`Updating DNA distribution for ${dnaType}`);
         
-        // Clear existing markers
+        // Clear existing markers (both regular markers and circle markers)
         map.eachLayer(layer => {
-            if (layer instanceof L.Marker) {
+            if (layer instanceof L.Marker || layer instanceof L.CircleMarker) {
                 map.removeLayer(layer);
             }
         });
@@ -623,7 +629,7 @@ class HeritageMaps {
         const fieldName = dnaType === 'ydna' ? 'yDnaHaplogroup' : 'mtDnaHaplogroup';
         let familyIndex = 0;
 
-        this.allData.forEach(family => {
+        this.data.forEach(family => {
             const haplogroup = family[fieldName];
             if (!haplogroup || !haplogroup.root) return;
 

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -82,8 +82,8 @@ class HeritageStatistics {
                 // Delay chart creation to ensure DOM is ready
                 setTimeout(() => {
                     if (!this.charts.yDna) {
-                        // Always start with global data when first opening statistics
-                        this.data = this.allData;
+                        // Create charts with current data (filtered or all)
+                        // Don't reset this.data - it should already be set by filters if applied
                         this.createAllCharts();
                     }
                 }, 100);
@@ -98,14 +98,10 @@ class HeritageStatistics {
     updateWithFilteredData(filteredData) {
         console.log(`📊 Updating statistics with ${filteredData.length} filtered families`);
         
-        // If no filters applied (full dataset), use all data
-        if (filteredData.length === this.allData.length) {
-            this.data = this.allData;
-        } else {
-            this.data = filteredData;
-        }
+        // Always use the provided filtered data
+        this.data = filteredData;
         
-        // Refresh all charts if they exist
+        // Refresh all charts if they exist, otherwise they'll be created with correct data when tab is clicked
         if (this.charts.yDna) {
             this.updateAllCharts();
         }


### PR DESCRIPTION
## Fix: Infographics filtering and display bugs

### Bug Fixes
- **Y-DNA/mtDNA maps**: Now properly respect ethnicity and location filters
- **Location dropdown**: Villages display in native language, states in English (eliminates duplicates like "Кабардино-Балкария" and "Kabardino-Balkaria")
- **Statistics charts**: Show filtered data immediately on first tab click (no longer resets to all data)
- **DNA distribution**: Properly clears CircleMarker instances when filters change (fixes marker accumulation bug)

### Technical Changes
- Updated `updateWithFilteredData()` in maps.js to refresh Y-DNA/mtDNA maps
- Changed `updateDNADistribution()` to use `this.data` (filtered) instead of `this.allData`
- Modified data-loader.js and main.js to prioritize native for villages, English for states
- Fixed CircleMarker clearing logic (was only clearing L.Marker instances)
- Removed data reset in statistics.js setupTabListener

Fixes filtering consistency across Feed, Maps, and Statistics views.