### PR TITLE
feat: updated schema and reduced complexity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,13 @@ jobs:
 
     - name: Fetch Heritage Data from GCP
       run: |
-        mkdir -p data
+        mkdir -p data config
         gsutil cp gs://${{ secrets.GCP_BUCKET_NAME }}/heritage-data.json data/heritage-data.json
-        gsutil cp gs://${{ secrets.GCP_BUCKET_NAME }}/config.json data/config.json
-        echo "✅ Data files fetched from GCP bucket"
+        gsutil cp gs://${{ secrets.GCP_BUCKET_NAME }}/config/app-config.json config/app-config.json
+        gsutil cp gs://${{ secrets.GCP_BUCKET_NAME }}/config/mapping-ethnicities.yaml config/mapping-ethnicities.yaml
+        gsutil cp gs://${{ secrets.GCP_BUCKET_NAME }}/config/mapping-villages.yaml config/mapping-villages.yaml
+        gsutil cp gs://${{ secrets.GCP_BUCKET_NAME }}/config/mapping-locations.yaml config/mapping-locations.yaml
+        echo "✅ Data and config files fetched from GCP bucket"
 
     - name: Validate HTML
       run: |
@@ -53,8 +56,10 @@ jobs:
 
     - name: Verify Data Files
       run: |
-        echo "Checking if data files exist..."
+        echo "Checking data files..."
         ls -lh data/
+        echo "Checking config files..."
+        ls -lh config/
         echo "Preview of heritage-data.json:"
         head -5 data/heritage-data.json
         echo "✅ Data files verified"
@@ -63,18 +68,23 @@ jobs:
       run: |
         echo "Creating deployment directory..."
         mkdir -p _deploy
-        
+
         # Copy website files
         cp -r index.html assets _deploy/
-        
-        # Copy data files from GCP
+
+        # Copy data files
         mkdir -p _deploy/data
         cp data/heritage-data.json _deploy/data/
-        cp data/config.json _deploy/data/
-        
+
+        # Copy config files (YAML mappings + app config)
+        mkdir -p _deploy/config
+        cp config/app-config.json _deploy/config/
+        cp config/mapping-ethnicities.yaml _deploy/config/
+        cp config/mapping-villages.yaml _deploy/config/
+        cp config/mapping-locations.yaml _deploy/config/
+
         echo "Deployment directory prepared:"
         find _deploy -type f
-        ls -lh _deploy/data/
         echo "✅ Ready to deploy"
 
     - name: Deploy to GitHub Pages

--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -137,7 +137,7 @@ class DataLoader {
             }
         } catch (error) {
             console.error('❌ Failed to load ethnicity mapping:', error);
-            this.ethnicityMapping = { main_ethnicities: {}, sub_groups: {} };
+            this.ethnicityMapping = { main_ethnicities: {}, sub_ethnicities: {} };
             return this.ethnicityMapping;
         }
     }
@@ -282,7 +282,7 @@ class DataLoader {
 
         if (subGroup) {
             // Get sub-group translation
-            const subGroups = this.ethnicityMapping.sub_groups?.[mainEthnicity];
+            const subGroups = this.ethnicityMapping.sub_ethnicities?.[mainEthnicity];
             if (subGroups && subGroups[subGroup]) {
                 const translation = subGroups[subGroup];
                 return {

--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -7,6 +7,12 @@ class DataLoader {
     constructor() {
         this.heritageData = null;
         this.config = null;
+        this.ethnicityMapping = null;
+        this.villageMapping = null;
+        this.locationMapping = null;
+        this.villageIndex = null;   // flat: russianVillageName → {names, coordinates}
+        this.stateIndex   = null;   // flat: russianStateName   → {names}
+        this.regionIndex  = null;   // flat: russianRegionName  → {names}
         this.basePath = this.getBasePath();
         this.cacheVersion = Date.now(); // Use timestamp for cache busting
 
@@ -41,6 +47,13 @@ class DataLoader {
         try {
             console.log('🔄 Loading data from:', `${this.basePath}data/heritage-data.json`);
             
+            // Load all mappings first
+            await Promise.all([
+                this.loadEthnicityMapping(),
+                this.loadVillageMapping(),
+                this.loadLocationMapping()
+            ]);
+            
             // Use timestamp for cache busting
             const response = await fetch(`${this.basePath}data/heritage-data.json?v=${this.cacheVersion}`);
             
@@ -51,7 +64,12 @@ class DataLoader {
             const data = await response.json();
             
             // Handle different JSON structures
-            this.heritageData = data.families || data || [];
+            let families = data.families || data || [];
+            
+            // Enrich each family with ethnicity translations and location data
+            families = families.map(family => this.enrichFamilyData(family));
+            
+            this.heritageData = families;
             
             console.log(`✅ Loaded ${this.heritageData.length} heritage records from JSON`);
             return this.heritageData;
@@ -93,6 +111,313 @@ class DataLoader {
             this.config = this.getDefaultConfig();
             return this.config;
         }
+    }
+
+    /**
+     * Load ethnicity mapping from YAML
+     */
+    async loadEthnicityMapping() {
+        if (this.ethnicityMapping) {
+            return this.ethnicityMapping;
+        }
+
+        try {
+            const url = `${this.basePath}config/mapping-ethnicities.yaml?v=${this.cacheVersion}`;
+            console.log('🔄 Loading ethnicity mapping from:', url);
+
+            const response = await fetch(url);
+
+            if (response.ok) {
+                const yamlText = await response.text();
+                this.ethnicityMapping = jsyaml.load(yamlText);
+                console.log('✅ Ethnicity mapping loaded');
+                return this.ethnicityMapping;
+            } else {
+                throw new Error(`HTTP ${response.status}`);
+            }
+        } catch (error) {
+            console.error('❌ Failed to load ethnicity mapping:', error);
+            this.ethnicityMapping = { main_ethnicities: {}, sub_groups: {} };
+            return this.ethnicityMapping;
+        }
+    }
+
+    /**
+     * Load village mapping from YAML
+     */
+    async loadVillageMapping() {
+        if (this.villageMapping) {
+            return this.villageMapping;
+        }
+
+        try {
+            const url = `${this.basePath}config/mapping-villages.yaml?v=${this.cacheVersion}`;
+            console.log('🔄 Loading village mapping from:', url);
+
+            const response = await fetch(url);
+
+            if (response.ok) {
+                const yamlText = await response.text();
+                this.villageMapping = jsyaml.load(yamlText);
+                this.buildVillageIndex();
+                console.log('✅ Village mapping loaded');
+                return this.villageMapping;
+            } else {
+                throw new Error(`HTTP ${response.status}`);
+            }
+        } catch (error) {
+            console.error('❌ Failed to load village mapping:', error);
+            this.villageMapping = { states: {} };
+            return this.villageMapping;
+        }
+    }
+
+    /**
+     * Load location mapping from YAML (states → regions with per-ethnicity names)
+     */
+    async loadLocationMapping() {
+        if (this.locationMapping) {
+            return this.locationMapping;
+        }
+
+        try {
+            const url = `${this.basePath}config/mapping-locations.yaml?v=${this.cacheVersion}`;
+            console.log('🔄 Loading location mapping from:', url);
+
+            const response = await fetch(url);
+
+            if (response.ok) {
+                const yamlText = await response.text();
+                this.locationMapping = jsyaml.load(yamlText);
+                this.buildLocationIndex();
+                console.log('✅ Location mapping loaded');
+                return this.locationMapping;
+            } else {
+                throw new Error(`HTTP ${response.status}`);
+            }
+        } catch (error) {
+            console.error('❌ Failed to load location mapping:', error);
+            this.locationMapping = { states: {} };
+            return this.locationMapping;
+        }
+    }
+
+    /**
+     * Build a flat village index from the hierarchical mapping-village.yaml.
+     * Key: Russian village name  →  { names: {English, Circassian, ...}, coordinates: {Latitude, Longitude} }
+     */
+    buildVillageIndex() {
+        this.villageIndex = {};
+        const states = this.villageMapping?.states;
+        if (!states) return;
+
+        for (const stateData of Object.values(states)) {
+            for (const regionData of Object.values(stateData.regions || {})) {
+                for (const [villageName, villageData] of Object.entries(regionData.villages || {})) {
+                    if (!villageData) continue; // skip incomplete YAML entries
+                    // villageName is the Russian key
+                    this.villageIndex[villageName] = {
+                        names:       villageData.name        || {},
+                        coordinates: villageData.coordinates || {}
+                    };
+                }
+            }
+        }
+        console.log(`📍 Village index built: ${Object.keys(this.villageIndex).length} entries`);
+    }
+
+    /**
+     * Build flat state and region indexes from mapping-locations.yaml.
+     * stateIndex  key: Russian state name  → { names }
+     * regionIndex key: Russian region name → { names }
+     */
+    buildLocationIndex() {
+        this.stateIndex  = {};
+        this.regionIndex = {};
+        const states = this.locationMapping?.states;
+        if (!states) return;
+
+        for (const [stateName, stateData] of Object.entries(states)) {
+            this.stateIndex[stateName] = { names: stateData.name || {} };
+            for (const [regionName, regionData] of Object.entries(stateData.regions || {})) {
+                this.regionIndex[regionName] = { names: regionData.name || {} };
+            }
+        }
+        console.log(`🗺️ Location index built: ${Object.keys(this.stateIndex).length} states, ${Object.keys(this.regionIndex).length} regions`);
+    }
+
+    /**
+     * Get village information from the flat villageIndex.
+     * @param {string} russianVillageName - Russian village name (JSON key)
+     * @param {string} ethnicity - Main English ethnicity (e.g. 'Circassian') for native name
+     * @returns {{ russian, native, english, latitude, longitude }}
+     */
+    getVillageInfo(russianVillageName, ethnicity = null) {
+        const empty = { russian: null, native: null, english: null, latitude: null, longitude: null };
+        if (!russianVillageName) return empty;
+
+        const entry = this.villageIndex?.[russianVillageName];
+        if (!entry) return { ...empty, russian: russianVillageName };
+
+        return {
+            russian:   entry.names.Russian   || russianVillageName,
+            native:    ethnicity ? (entry.names[ethnicity] || null) : null,
+            english:   entry.names.English   || null,
+            latitude:  entry.coordinates.Latitude  ?? null,
+            longitude: entry.coordinates.Longitude ?? null
+        };
+    }
+
+    /**
+     * Get ethnicity translations from mapping
+     * @param {string} mainEthnicity - Main ethnicity English name
+     * @param {string} subGroup - Sub-group English name (optional)
+     * @param {string} gender - 'male' or 'female' (for gender-specific Russian)
+     * @returns {object} - Object with russian and native translations
+     */
+    getEthnicityTranslation(mainEthnicity, subGroup = null, gender = 'male') {
+        if (!this.ethnicityMapping) {
+            return { russian: null, native: null };
+        }
+
+        if (subGroup) {
+            // Get sub-group translation
+            const subGroups = this.ethnicityMapping.sub_groups?.[mainEthnicity];
+            if (subGroups && subGroups[subGroup]) {
+                const translation = subGroups[subGroup];
+                return {
+                    russian: gender === 'female' && translation.russian_female ? translation.russian_female : translation.russian,
+                    native: translation.native
+                };
+            }
+        } else {
+            // Get main ethnicity translation
+            const mainEth = this.ethnicityMapping.main_ethnicities?.[mainEthnicity];
+            if (mainEth) {
+                return {
+                    russian: gender === 'female' && mainEth.russian_female ? mainEth.russian_female : mainEth.russian,
+                    native: mainEth.native
+                };
+            }
+        }
+
+        return { russian: null, native: null };
+    }
+
+    /**
+     * Enrich family data with ethnicity and location translations
+     * @param {object} family - Family object with English-only ethnicity and native-only locations
+     * @returns {object} - Family object with all translations and coordinates
+     */
+    enrichFamilyData(family) {
+        // Enrich ethnicity
+        if (family.ethnicity) {
+            // Enrich main ethnicity
+            if (family.ethnicity.main) {
+                const mainEng = family.ethnicity.main.english;
+                if (mainEng) {
+                    const translation = this.getEthnicityTranslation(mainEng, null, family.gender);
+                    family.ethnicity.main.russian = translation.russian;
+                    family.ethnicity.main.native = translation.native;
+
+                    // Enrich main sub-group
+                    if (family.ethnicity.main.sub && family.ethnicity.main.sub.english) {
+                        const subEng = family.ethnicity.main.sub.english;
+                        const subTranslation = this.getEthnicityTranslation(mainEng, subEng, family.gender);
+                        family.ethnicity.main.sub.russian = subTranslation.russian;
+                        family.ethnicity.main.sub.native = subTranslation.native;
+                    }
+                }
+            }
+
+            // Enrich pre ethnicity
+            if (family.ethnicity.pre) {
+                const preEng = family.ethnicity.pre.english;
+                if (preEng) {
+                    const translation = this.getEthnicityTranslation(preEng, null, family.gender);
+                    family.ethnicity.pre.russian = translation.russian;
+                    family.ethnicity.pre.native = translation.native;
+
+                    // Enrich pre sub-group
+                    if (family.ethnicity.pre.sub && family.ethnicity.pre.sub.english) {
+                        const subEng = family.ethnicity.pre.sub.english;
+                        const subTranslation = this.getEthnicityTranslation(preEng, subEng, family.gender);
+                        family.ethnicity.pre.sub.russian = subTranslation.russian;
+                        family.ethnicity.pre.sub.native = subTranslation.native;
+                    }
+                }
+            }
+        }
+
+        // Enrich location from YAML indexes.
+        // JSON now stores plain Russian strings; we expand them into {russian, native, english} objects
+        // and add a coordinates block derived from the village mapping.
+        if (family.location) {
+            const ethnicity = family.ethnicity?.main?.english || null;
+
+            // Helper: extract plain Russian string from a simple-format or already-enriched field
+            const toRussian = (val) => {
+                if (!val) return null;
+                if (typeof val === 'string') return val || null;
+                return val.russian || null;
+            };
+
+            // Helper: look up state/region names by Russian key
+            const enrichState = (russianName) => {
+                if (!russianName) return { russian: null, native: null, english: null };
+                const entry = this.stateIndex?.[russianName];
+                if (!entry) return { russian: russianName, native: null, english: null };
+                return {
+                    russian: entry.names.Russian || russianName,
+                    native:  ethnicity ? (entry.names[ethnicity] || null) : null,
+                    english: entry.names.English  || null
+                };
+            };
+
+            const enrichRegion = (russianName) => {
+                if (!russianName) return { russian: null, native: null, english: null };
+                const entry = this.regionIndex?.[russianName];
+                if (!entry) return { russian: russianName, native: null, english: null };
+                return {
+                    russian: entry.names.Russian || russianName,
+                    native:  ethnicity ? (entry.names[ethnicity] || null) : null,
+                    english: entry.names.English  || null
+                };
+            };
+
+            const mainVillage = toRussian(family.location.village?.main);
+            const preVillage  = toRussian(family.location.village?.pre);
+            const mainRegion  = toRussian(family.location.region?.main);
+            const preRegion   = toRussian(family.location.region?.pre);
+            const mainState   = toRussian(family.location.state?.main);
+            const preState    = toRussian(family.location.state?.pre);
+
+            // Expand villages (get native/english/coords from index)
+            const mainVillageInfo = this.getVillageInfo(mainVillage, ethnicity);
+            const preVillageInfo  = this.getVillageInfo(preVillage,  ethnicity);
+
+            family.location.village = {
+                main: { russian: mainVillageInfo.russian, native: mainVillageInfo.native, english: mainVillageInfo.english },
+                pre:  { russian: preVillageInfo.russian,  native: preVillageInfo.native,  english: preVillageInfo.english  }
+            };
+
+            family.location.region = {
+                main: enrichRegion(mainRegion),
+                pre:  enrichRegion(preRegion)
+            };
+
+            family.location.state = {
+                main: enrichState(mainState),
+                pre:  enrichState(preState)
+            };
+
+            family.location.coordinates = {
+                main: { latitude: mainVillageInfo.latitude, longitude: mainVillageInfo.longitude },
+                pre:  { latitude: preVillageInfo.latitude,  longitude: preVillageInfo.longitude  }
+            };
+        }
+
+        return family;
     }
 
     /**

--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -313,8 +313,8 @@ class DataLoader {
 
     /**
      * Enrich family data with ethnicity and location translations
-     * @param {object} family - Family object with English-only ethnicity and native-only locations
-     * @returns {object} - Family object with all translations and coordinates
+     * @param {object} family - Family object with English-only ethnicity and Russian-only location strings (expanded at runtime)
+     * @returns {object} - Family object with enriched translations (including locations) and coordinates
      */
     enrichFamilyData(family) {
         // Enrich ethnicity
@@ -383,12 +383,10 @@ class DataLoader {
 
             const enrichRegion = (russianName, russianState) => {
                 if (!russianName) return { russian: null, native: null, english: null };
-                // Look up by composite "state::region" key first to avoid collisions
+                // Look up by composite "state::region" key to avoid collisions
                 // (e.g. 'Ногайский район' appears in both KCR and Dagestan).
                 const compositeKey = russianState ? `${russianState}::${russianName}` : null;
-                const entry = (compositeKey && this.regionIndex?.[compositeKey])
-                    || this.regionIndex?.[russianName]  // fallback for unscoped lookups
-                    || null;
+                const entry = compositeKey ? this.regionIndex?.[compositeKey] : null;
                 if (!entry) return { russian: russianName, native: null, english: null };
                 return {
                     russian: entry.names.Russian || russianName,

--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -94,7 +94,7 @@ class DataLoader {
         }
 
         try {
-            const url = `${this.basePath}data/config.json?v=${this.cacheVersion}`;
+            const url = `${this.basePath}config/app-config.json?v=${this.cacheVersion}`;
             console.log('🔄 Loading config from:', url);
 
             const response = await fetch(url);
@@ -547,7 +547,7 @@ class DataLoader {
             app: {
                 title: "Circassian DNA",
                 subtitle: "Genetic lineage and ancestral connections",
-                version: "2.0.0"
+                version: "4.0.0"
             },
             filters: {
                 ethnicities: [

--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -3,6 +3,9 @@
  * Only loads from JSON file - single source of truth
  */
 
+/** Single source of truth for the config/YAML cache version. Bump on every release. */
+const CONFIG_VERSION = '4.0.0';
+
 class DataLoader {
     constructor() {
         this.heritageData = null;
@@ -11,10 +14,10 @@ class DataLoader {
         this.villageMapping = null;
         this.locationMapping = null;
         this.villageIndex = null;   // flat: russianVillageName → {names, coordinates}
-        this.stateIndex   = null;   // flat: russianStateName   → {names}
-        this.regionIndex  = null;   // flat: russianRegionName  → {names}
+        this.stateIndex   = null;   // flat: russianStateName             → {names}
+        this.regionIndex  = null;   // composite: "state::region" (Russian) → {names}
         this.basePath = this.getBasePath();
-        this.configVersion = '4.0.0';  // Stable: bump with releases to invalidate YAML/config cache
+        this.configVersion = CONFIG_VERSION;  // Stable: bump CONFIG_VERSION with releases to invalidate YAML/config cache
         this.dataVersion   = Date.now(); // Dynamic: always fresh for heritage-data.json
 
         console.log('📁 DataLoader initialized with base path:', this.basePath);
@@ -229,8 +232,10 @@ class DataLoader {
 
     /**
      * Build flat state and region indexes from mapping-locations.yaml.
-     * stateIndex  key: Russian state name  → { names }
-     * regionIndex key: Russian region name → { names }
+     * stateIndex  key: Russian state name              → { names }
+     * regionIndex key: "state::region" (Russian names) → { names }
+     *   Composite key avoids collisions where two states share a region name
+     *   (e.g. 'Ногайский район' exists in both KCR and Dagestan).
      */
     buildLocationIndex() {
         this.stateIndex  = {};
@@ -241,7 +246,8 @@ class DataLoader {
         for (const [stateName, stateData] of Object.entries(states)) {
             this.stateIndex[stateName] = { names: stateData.name || {} };
             for (const [regionName, regionData] of Object.entries(stateData.regions || {})) {
-                this.regionIndex[regionName] = { names: regionData.name || {} };
+                const compositeKey = `${stateName}::${regionName}`;
+                this.regionIndex[compositeKey] = { names: regionData.name || {} };
             }
         }
         console.log(`🗺️ Location index built: ${Object.keys(this.stateIndex).length} states, ${Object.keys(this.regionIndex).length} regions`);
@@ -375,9 +381,14 @@ class DataLoader {
                 };
             };
 
-            const enrichRegion = (russianName) => {
+            const enrichRegion = (russianName, russianState) => {
                 if (!russianName) return { russian: null, native: null, english: null };
-                const entry = this.regionIndex?.[russianName];
+                // Look up by composite "state::region" key first to avoid collisions
+                // (e.g. 'Ногайский район' appears in both KCR and Dagestan).
+                const compositeKey = russianState ? `${russianState}::${russianName}` : null;
+                const entry = (compositeKey && this.regionIndex?.[compositeKey])
+                    || this.regionIndex?.[russianName]  // fallback for unscoped lookups
+                    || null;
                 if (!entry) return { russian: russianName, native: null, english: null };
                 return {
                     russian: entry.names.Russian || russianName,
@@ -403,8 +414,8 @@ class DataLoader {
             };
 
             family.location.region = {
-                main: enrichRegion(mainRegion),
-                pre:  enrichRegion(preRegion)
+                main: enrichRegion(mainRegion, mainState),
+                pre:  enrichRegion(preRegion,  preState)
             };
 
             family.location.state = {
@@ -548,7 +559,7 @@ class DataLoader {
             app: {
                 title: "Circassian DNA",
                 subtitle: "Genetic lineage and ancestral connections",
-                version: "4.0.0"
+                version: CONFIG_VERSION
             },
             filters: {
                 ethnicities: [
@@ -614,68 +625,7 @@ class DataLoader {
     }
     
     /**
-     * Multi-filter data by ethnicity, village, state, and clade
-     */
-    getMultiFilteredData(filters = {}) {
-        if (!this.heritageData) {
-            return [];
-        }
-        
-        return this.heritageData.filter(family => {
-            // Ethnicity filter
-            if (filters.ethnicity && filters.ethnicity !== 'all') {
-                const mainEthnicity = family.ethnicity?.main?.english;
-                const subEthnicity = family.ethnicity?.main?.sub?.english;
-                const filterEth = filters.ethnicity.toLowerCase();
-                
-                const ethMatch = 
-                    (mainEthnicity && mainEthnicity.toLowerCase() === filterEth) ||
-                    (subEthnicity && subEthnicity.toLowerCase() === filterEth);
-                
-                if (!ethMatch) return false;
-            }
-            
-            // Village filter
-            if (filters.village && filters.village !== 'all') {
-                const villageNative = family.location?.village?.main?.native;
-                const villageRussian = family.location?.village?.main?.russian;
-                const villageEnglish = family.location?.village?.main?.english;
-                
-                const villageMatch = 
-                    villageNative === filters.village ||
-                    villageRussian === filters.village ||
-                    villageEnglish === filters.village;
-                
-                if (!villageMatch) return false;
-            }
-            
-            // State filter
-            if (filters.state && filters.state !== 'all') {
-                const stateNative = family.location?.state?.main?.native;
-                const stateRussian = family.location?.state?.main?.russian;
-                const stateEnglish = family.location?.state?.main?.english;
-                
-                const stateMatch = 
-                    stateNative === filters.state ||
-                    stateRussian === filters.state ||
-                    stateEnglish === filters.state;
-                
-                if (!stateMatch) return false;
-            }
-            
-            // Clade filter (Y-DNA haplogroup)
-            if (filters.clade && filters.clade !== 'all') {
-                const hg = family.yDnaHaplogroup;
-                const clade = typeof hg === 'object' ? hg.clade : hg;
-                
-                if (clade !== filters.clade) return false;
-            }
-            
-            return true;
-        });
-    }    
-    /**
-     * Multi-filter data by ethnicity, village, state, and clade
+     * Multi-filter data by ethnicity, village, state, and clade (supports arrays + legacy single values)
      */
     getMultiFilteredData(filters = {}) {
         if (!this.heritageData) {
@@ -861,19 +811,10 @@ class DataLoader {
     }
 
     /**
-     * Get processed data with filtering and sorting
+     * Get processed (filtered + sorted) data
      * @param {Object|string} filters - Filter object {ethnicity, village, state, clade} or legacy ethnicity string
      * @param {string} sortType - Sort type
      */
-    getProcessedData(filters = 'all', sortType = 'date-desc') {
-        // Handle legacy single ethnicity filter
-        if (typeof filters === 'string') {
-            filters = { ethnicity: filters };
-        }
-        
-        const filtered = this.getMultiFilteredData(filters);
-        return this.sortData(filtered, sortType);
-    }
     getProcessedData(filters = 'all', sortType = 'date-desc') {
         // Handle legacy single ethnicity filter
         if (typeof filters === 'string') {

--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -14,7 +14,8 @@ class DataLoader {
         this.stateIndex   = null;   // flat: russianStateName   → {names}
         this.regionIndex  = null;   // flat: russianRegionName  → {names}
         this.basePath = this.getBasePath();
-        this.cacheVersion = Date.now(); // Use timestamp for cache busting
+        this.configVersion = '4.0.0';  // Stable: bump with releases to invalidate YAML/config cache
+        this.dataVersion   = Date.now(); // Dynamic: always fresh for heritage-data.json
 
         console.log('📁 DataLoader initialized with base path:', this.basePath);
     }
@@ -55,7 +56,7 @@ class DataLoader {
             ]);
             
             // Use timestamp for cache busting
-            const response = await fetch(`${this.basePath}data/heritage-data.json?v=${this.cacheVersion}`);
+            const response = await fetch(`${this.basePath}data/heritage-data.json?v=${this.dataVersion}`);
             
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -63,13 +64,13 @@ class DataLoader {
             
             const data = await response.json();
             
-            // Handle different JSON structures
-            let families = data.families || data || [];
-            
+            // Normalize to array regardless of JSON structure
+            const families = Array.isArray(data.families) ? data.families
+                           : Array.isArray(data)          ? data
+                           : [];
+
             // Enrich each family with ethnicity translations and location data
-            families = families.map(family => this.enrichFamilyData(family));
-            
-            this.heritageData = families;
+            this.heritageData = families.map(family => this.enrichFamilyData(family));
             
             console.log(`✅ Loaded ${this.heritageData.length} heritage records from JSON`);
             return this.heritageData;
@@ -94,7 +95,7 @@ class DataLoader {
         }
 
         try {
-            const url = `${this.basePath}config/app-config.json?v=${this.cacheVersion}`;
+            const url = `${this.basePath}config/app-config.json?v=${this.configVersion}`;
             console.log('🔄 Loading config from:', url);
 
             const response = await fetch(url);
@@ -122,7 +123,7 @@ class DataLoader {
         }
 
         try {
-            const url = `${this.basePath}config/mapping-ethnicities.yaml?v=${this.cacheVersion}`;
+            const url = `${this.basePath}config/mapping-ethnicities.yaml?v=${this.configVersion}`;
             console.log('🔄 Loading ethnicity mapping from:', url);
 
             const response = await fetch(url);
@@ -151,7 +152,7 @@ class DataLoader {
         }
 
         try {
-            const url = `${this.basePath}config/mapping-villages.yaml?v=${this.cacheVersion}`;
+            const url = `${this.basePath}config/mapping-villages.yaml?v=${this.configVersion}`;
             console.log('🔄 Loading village mapping from:', url);
 
             const response = await fetch(url);
@@ -181,7 +182,7 @@ class DataLoader {
         }
 
         try {
-            const url = `${this.basePath}config/mapping-locations.yaml?v=${this.cacheVersion}`;
+            const url = `${this.basePath}config/mapping-locations.yaml?v=${this.configVersion}`;
             console.log('🔄 Loading location mapping from:', url);
 
             const response = await fetch(url);
@@ -203,7 +204,7 @@ class DataLoader {
     }
 
     /**
-     * Build a flat village index from the hierarchical mapping-village.yaml.
+     * Build a flat village index from the hierarchical mapping-villages.yaml.
      * Key: Russian village name  →  { names: {English, Circassian, ...}, coordinates: {Latitude, Longitude} }
      */
     buildVillageIndex() {

--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -337,13 +337,20 @@ class HeritageMaps {
         const mtDnaGroups = {};
         
         families.forEach(family => {
-            const yDna = family.yDnaHaplogroup;
-            const mtDna = family.mtDnaHaplogroup;
-            
-            if (yDna && yDna !== 'N/A') {
+            const yDnaObj = family.yDnaHaplogroup;
+            const mtDnaObj = family.mtDnaHaplogroup;
+
+            const yDna = typeof yDnaObj === 'string'
+                ? yDnaObj
+                : (yDnaObj?.clade || yDnaObj?.root || null);
+            const mtDna = typeof mtDnaObj === 'string'
+                ? mtDnaObj
+                : (mtDnaObj?.clade || mtDnaObj?.root || null);
+
+            if (yDna && yDna !== 'N/A' && yDna !== '—') {
                 yDnaGroups[yDna] = (yDnaGroups[yDna] || 0) + 1;
             }
-            if (mtDna && mtDna !== 'N/A') {
+            if (mtDna && mtDna !== 'N/A' && mtDna !== '—') {
                 mtDnaGroups[mtDna] = (mtDnaGroups[mtDna] || 0) + 1;
             }
         });

--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -337,8 +337,8 @@ class HeritageMaps {
         const mtDnaGroups = {};
         
         families.forEach(family => {
-            const yDna = family.dna?.yDnaHaplogroup;
-            const mtDna = family.dna?.mtDnaHaplogroup;
+            const yDna = family.yDnaHaplogroup;
+            const mtDna = family.mtDnaHaplogroup;
             
             if (yDna && yDna !== 'N/A') {
                 yDnaGroups[yDna] = (yDnaGroups[yDna] || 0) + 1;
@@ -427,6 +427,9 @@ class HeritageMaps {
 
         // Add migration paths
         this.addMigrationPaths();
+
+        // Leaflet needs a repaint frame after display:none→block to measure the container correctly
+        setTimeout(() => this.maps.migration?.invalidateSize(), 0);
 
         // Update legend
         const legend = document.getElementById('migrationLegend');
@@ -558,12 +561,14 @@ class HeritageMaps {
                 </div>
             `);
             
+            const baseOffsetDeg = 0.0002; // ~22m at equator; much smaller than 0.01deg (~1.1km)
+
             // Track and offset "from" markers
             const fromKey = `${group.from.lat.toFixed(4)},${group.from.lng.toFixed(4)}`;
             fromCoordsCount[fromKey] = (fromCoordsCount[fromKey] || 0) + 1;
             const fromOffset = fromCoordsCount[fromKey] - 1;
             const fromAngle = fromOffset * (Math.PI * 2 / 5);
-            const fromDistance = Math.ceil(fromOffset / 5) * 0.01;
+            const fromDistance = Math.ceil(fromOffset / 5) * baseOffsetDeg;
             const fromOffsetLat = fromOffset > 0 ? Math.sin(fromAngle) * fromDistance : 0;
             const fromOffsetLng = fromOffset > 0 ? Math.cos(fromAngle) * fromDistance : 0;
             
@@ -572,7 +577,7 @@ class HeritageMaps {
             toCoordsCount[toKey] = (toCoordsCount[toKey] || 0) + 1;
             const toOffset = toCoordsCount[toKey] - 1;
             const toAngle = toOffset * (Math.PI * 2 / 5);
-            const toDistance = Math.ceil(toOffset / 5) * 0.01;
+            const toDistance = Math.ceil(toOffset / 5) * baseOffsetDeg;
             const toOffsetLat = toOffset > 0 ? Math.sin(toAngle) * toDistance : 0;
             const toOffsetLng = toOffset > 0 ? Math.cos(toAngle) * toDistance : 0;
             
@@ -618,6 +623,9 @@ class HeritageMaps {
 
         // Display Y-DNA data
         this.updateDNADistribution('ydna', this.maps.ydna, 'ydnaLegend');
+
+        // Leaflet needs a repaint frame after display:none→block to measure the container correctly
+        setTimeout(() => this.maps.ydna?.invalidateSize(), 0);
     }
 
     /**
@@ -719,7 +727,8 @@ class HeritageMaps {
                 
                 // Apply small offset to prevent perfect overlap (spiral pattern)
                 const angle = offset * (Math.PI * 2 / 5); // 5 markers per circle
-                const distance = Math.ceil(offset / 5) * 0.01; // Increase radius every 5 markers
+                const baseOffsetDeg = 0.0002; // ~22m at equator; much smaller than 0.01deg (~1.1km)
+                const distance = Math.ceil(offset / 5) * baseOffsetDeg; // Increase radius every 5 markers
                 const offsetLat = offset > 0 ? Math.sin(angle) * distance : 0;
                 const offsetLng = offset > 0 ? Math.cos(angle) * distance : 0;
                 

--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -481,7 +481,9 @@ class HeritageMaps {
             
             // Get haplogroup color
             const haplogroup = family.yDnaHaplogroup;
-            const subclade = haplogroup?.subclade || haplogroup?.clade || haplogroup?.root || 'Unknown';
+            const subclade = typeof haplogroup === 'string'
+                ? haplogroup
+                : (haplogroup?.subclade || haplogroup?.clade || haplogroup?.root || 'Unknown');
             const color = haplogroup ? HaplotypeConfig.getYSubcladeColor(subclade) : '#999999';
             
             migrations.push({
@@ -664,12 +666,17 @@ class HeritageMaps {
 
         this.data.forEach(family => {
             const haplogroup = family[fieldName];
-            if (!haplogroup || !haplogroup.root) return;
+            if (!haplogroup) return;
+            // Support both object {root, clade, subclade} and plain string
+            const hapRoot = typeof haplogroup === 'string' ? haplogroup : haplogroup.root;
+            if (!hapRoot) return;
 
             const coords = family.location?.coordinates?.main;
             if (!coords || !coords.latitude || !coords.longitude) return;
 
-            const subclade = haplogroup.subclade || haplogroup.clade || haplogroup.root;
+            const subclade = typeof haplogroup === 'string'
+                ? haplogroup
+                : (haplogroup.subclade || haplogroup.clade || haplogroup.root);
 
             if (!subclades[subclade]) {
                 subclades[subclade] = {

--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -680,7 +680,13 @@ class HeritageMaps {
             if (!hapRoot) return;
 
             const coords = family.location?.coordinates?.main;
-            if (!coords || !coords.latitude || !coords.longitude) return;
+            if (
+                !coords ||
+                !Number.isFinite(coords.latitude) ||
+                !Number.isFinite(coords.longitude)
+            ) {
+                return;
+            }
 
             const subclade = typeof haplogroup === 'string'
                 ? haplogroup

--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -281,7 +281,7 @@ class HeritageMaps {
         if (!family.location?.village?.main) return null;
         
         const village = family.location.village.main;
-        return village.english || village.native || village.russian || 'Unknown';
+        return village.native || village.russian || village.english || 'Unknown';
     }
 
     /**
@@ -479,10 +479,17 @@ class HeritageMaps {
                 return;
             }
             
+            // Get haplogroup color
+            const haplogroup = family.yDnaHaplogroup;
+            const subclade = haplogroup?.subclade || haplogroup?.clade || haplogroup?.root || 'Unknown';
+            const color = haplogroup ? HaplotypeConfig.getYSubcladeColor(subclade) : '#999999';
+            
             migrations.push({
                 family: family,
                 from: preCoords,
                 to: mainCoords,
+                color: color,
+                subclade: subclade,
                 preVillage: family.location?.village?.pre?.english || 
                            family.location?.village?.pre?.native || 
                            family.location?.village?.pre?.russian || 'Unknown',
@@ -492,14 +499,16 @@ class HeritageMaps {
 
         console.log(`Found ${migrations.length} migration paths`);
 
-        // Group migrations by path for better visualization
+        // Group migrations by path AND haplogroup for better visualization
         const pathGroups = {};
         migrations.forEach(mig => {
-            const key = `${mig.from.lat},${mig.from.lng}-${mig.to.lat},${mig.to.lng}`;
+            const key = `${mig.from.lat},${mig.from.lng}-${mig.to.lat},${mig.to.lng}-${mig.subclade}`;
             if (!pathGroups[key]) {
                 pathGroups[key] = {
                     from: mig.from,
                     to: mig.to,
+                    color: mig.color,
+                    subclade: mig.subclade,
                     preVillage: mig.preVillage,
                     mainVillage: mig.mainVillage,
                     families: []
@@ -508,7 +517,10 @@ class HeritageMaps {
             pathGroups[key].families.push(mig.family);
         });
 
-        // Draw migration paths
+        // Draw migration paths with offset tracking
+        const fromCoordsCount = {};
+        const toCoordsCount = {};
+        
         Object.values(pathGroups).forEach(group => {
             const familyCount = group.families.length;
             
@@ -519,7 +531,7 @@ class HeritageMaps {
             ];
             
             const line = L.polyline(latlngs, {
-                color: 'var(--male-color)',
+                color: group.color,
                 weight: Math.min(2 + familyCount, 8),
                 opacity: 0.6,
                 dashArray: '10, 5'
@@ -538,31 +550,52 @@ class HeritageMaps {
                     <span style="font-size: 0.85rem;">
                         From: ${group.preVillage}<br>
                         To: ${group.mainVillage}<br>
+                        Haplogroup: ${group.subclade}<br>
                         Families: ${familyCount}
                     </span>
                 </div>
             `);
             
-            // Add markers at start and end
-            L.circleMarker([group.from.lat, group.from.lng], {
-                radius: 5,
-                fillColor: '#ffc107',
-                color: 'white',
-                weight: 2,
-                opacity: 1,
-                fillOpacity: 0.8
-            }).addTo(this.maps.migration)
-              .bindPopup(`<strong>${group.preVillage}</strong><br>Origin`);
+            // Track and offset "from" markers
+            const fromKey = `${group.from.lat.toFixed(4)},${group.from.lng.toFixed(4)}`;
+            fromCoordsCount[fromKey] = (fromCoordsCount[fromKey] || 0) + 1;
+            const fromOffset = fromCoordsCount[fromKey] - 1;
+            const fromAngle = fromOffset * (Math.PI * 2 / 5);
+            const fromDistance = Math.ceil(fromOffset / 5) * 0.01;
+            const fromOffsetLat = fromOffset > 0 ? Math.sin(fromAngle) * fromDistance : 0;
+            const fromOffsetLng = fromOffset > 0 ? Math.cos(fromAngle) * fromDistance : 0;
             
-            L.circleMarker([group.to.lat, group.to.lng], {
+            // Track and offset "to" markers
+            const toKey = `${group.to.lat.toFixed(4)},${group.to.lng.toFixed(4)}`;
+            toCoordsCount[toKey] = (toCoordsCount[toKey] || 0) + 1;
+            const toOffset = toCoordsCount[toKey] - 1;
+            const toAngle = toOffset * (Math.PI * 2 / 5);
+            const toDistance = Math.ceil(toOffset / 5) * 0.01;
+            const toOffsetLat = toOffset > 0 ? Math.sin(toAngle) * toDistance : 0;
+            const toOffsetLng = toOffset > 0 ? Math.cos(toAngle) * toDistance : 0;
+            
+            // Add markers at start and end with offsets and haplogroup colors
+            // "From" marker: hollow circle (open circle)
+            L.circleMarker([group.from.lat + fromOffsetLat, group.from.lng + fromOffsetLng], {
                 radius: 6,
-                fillColor: 'var(--male-color)',
-                color: 'white',
+                fillColor: group.color,
+                color: group.color,
                 weight: 2,
                 opacity: 1,
-                fillOpacity: 0.9
+                fillOpacity: 0  // Hollow/open circle
             }).addTo(this.maps.migration)
-              .bindPopup(`<strong>${group.mainVillage}</strong><br>Current location`);
+              .bindPopup(`<strong>${group.preVillage}</strong><br>Origin<br>${group.subclade}`);
+            
+            // "To" marker: filled circle
+            L.circleMarker([group.to.lat + toOffsetLat, group.to.lng + toOffsetLng], {
+                radius: 6,
+                fillColor: group.color,
+                color: '#fff',
+                weight: 2,
+                opacity: 1,
+                fillOpacity: 0.9  // Filled circle
+            }).addTo(this.maps.migration)
+              .bindPopup(`<strong>${group.mainVillage}</strong><br>Current location<br>${group.subclade}`);
         });
 
         console.log(`✅ Added ${Object.keys(pathGroups).length} migration path groups`);
@@ -664,11 +697,27 @@ class HeritageMaps {
                       totalFamilies < 500 ? baseRadius * 0.6 : 
                       baseRadius * 0.5;
 
+        // Track coordinates to add offset for overlapping markers
+        const coordsCount = {};
+        
         // Add circle markers for each family
         Object.entries(subclades).forEach(([subclade, data]) => {
             data.families.forEach(({ family, coords }) => {
+                // Create unique key for this coordinate
+                const coordKey = `${coords.latitude.toFixed(4)},${coords.longitude.toFixed(4)}`;
+                
+                // Get offset count for this coordinate
+                coordsCount[coordKey] = (coordsCount[coordKey] || 0) + 1;
+                const offset = coordsCount[coordKey] - 1;
+                
+                // Apply small offset to prevent perfect overlap (spiral pattern)
+                const angle = offset * (Math.PI * 2 / 5); // 5 markers per circle
+                const distance = Math.ceil(offset / 5) * 0.01; // Increase radius every 5 markers
+                const offsetLat = offset > 0 ? Math.sin(angle) * distance : 0;
+                const offsetLng = offset > 0 ? Math.cos(angle) * distance : 0;
+                
                 // Create circle marker with subclade color
-                const marker = L.circleMarker([coords.latitude, coords.longitude], {
+                const marker = L.circleMarker([coords.latitude + offsetLat, coords.longitude + offsetLng], {
                     radius: radius,
                     fillColor: data.color,
                     color: '#fff',

--- a/config/mapping-ethnicities.yaml
+++ b/config/mapping-ethnicities.yaml
@@ -1,0 +1,181 @@
+# Ethnicity Translation Mapping
+# Maps English names to Russian and Native language equivalents
+# Used to centralize translations instead of repeating them in each family record
+
+main_ethnicities:
+  Abazin:
+    russian: Абазин
+    russian_female: Абазинка
+    native: Абаза
+    native_female: null
+    
+  Abkhazian:
+    russian: Абхаз
+    russian_female: Абхазка
+    native: Аԥсуаа
+    native_female: null
+    
+  Balkar:
+    russian: Балкарец
+    russian_female: Балкарка
+    native: Таулу
+    native_female: null
+    
+  Circassian:
+    russian: Черкес
+    russian_female: Черкешенка
+    native: Адыгэ
+    native_female: null
+    
+  Karachay:
+    russian: Карачаевец
+    russian_female: Карачаевка
+    native: Къарачайлы
+    native_female: null
+
+  Kumyk:
+    russian: Кумык
+    russian_female: Кумычка
+    native: Къумукъ
+    native_female: null
+
+  Lak:
+    russian: Лакец
+    russian_female: Лачка
+    native: Лаккучу
+    native_female: Лаккудуш
+    
+  Nogai:
+    russian: Ногаец
+    russian_female: Ногайка
+    native: Ноғай
+    native_female: null
+    
+  Ossetian:
+    russian: Осетин
+    russian_female: Осетинка
+    native: Осетин
+    native_female: null
+    
+  Ubykh:
+    russian: Убых
+    russian_female: Убышка
+    native: Убых
+    native_female: null
+
+sub_ethnicities:
+  Abazin:
+    Ashkharaua:
+      russian: Ашхарауа
+      russian_female: Ашхарауа
+      native: Щхъарауа
+      native_female: null
+    Tapanta:
+      russian: Тапанта
+      russian_female: Тапанта
+      native: Ашвыуа
+      native_female: null
+      
+  Abkhazian:
+    Pskhu:
+      russian: Псху
+      russian_female: Псху
+      native: Ԥсҳәы
+      native_female: null
+      
+  Balkar:
+    Baksan:
+      russian: Баксан
+      russian_female: Баксан
+      native: Басханлы
+      native_female: null
+    Bezengi:
+      russian: Безенги
+      russian_female: Безенги
+      native: Бызынгылы
+      native_female: null
+    Chegem:
+      russian: Чегем
+      russian_female: Чегем
+      native: Чегемлы
+      native_female: null
+    Kholam:
+      russian: Холам
+      russian_female: Холам
+      native: Холамлы
+      native_female: null
+    Malkar:
+      russian: Малкар
+      russian_female: Малкар
+      native: Малкъарлы
+      native_female: null
+      
+  Circassian:
+    Abdzakh:
+      russian: Абадзех
+      russian_female: Абадзешка
+      native: Абдзах
+      native_female: null
+    Kabardian:
+      russian: Кабардинец
+      russian_female: Кабардинка
+      native: Къэбардей
+      native_female: null
+    Shapsough:
+      russian: Шапсуг
+      russian_female: Шапсуженка
+      native: Шапсыгъ
+      native_female: null
+    Ubykh:
+      russian: Убых
+      russian_female: Убышка
+      native: Убых
+      native_female: null
+      
+  Nogai:
+    Achikulak:
+      russian: Ачикулакский
+      russian_female: Ачикулакская
+      native: Ашыкъулак
+    Karanogai:
+      russian: Караногаец
+      russian_female: Караногайка
+      native: Караноғай
+    Karagash:
+      russian: Карагашский
+      russian_female: Карагашская
+      native: Карагаш
+    Kuban:
+      russian: Кубанский
+      russian_female: Кубанская
+      native: Кобан
+    Crimean:
+      russian: Крымский
+      russian_female: Крымская
+      native: Къырым
+    Sulak:
+      russian: Сулакский
+      russian_female: Сулакская
+      native: Сулак
+    Yurt:
+      russian: Юртовский
+      russian_female: Юртовская
+      native: Юрт
+      native_female: null
+      
+  Ossetian:
+    Digor:
+      russian: Дигорец
+      russian_female: Дигорка
+      native: Дигорон
+      native_female: null
+    Iron:
+      russian: Иронец
+      russian_female: Иронка
+      native: Ирон
+      native_female: null
+    Kudar:
+      russian: Кударец
+      russian_female: Кударка
+      native: Къуыдар
+      native_female: null

--- a/config/mapping-locations.yaml
+++ b/config/mapping-locations.yaml
@@ -1,0 +1,881 @@
+
+
+
+states:
+
+  Абхазия:
+    name:
+      English: Abkhazia
+      Russian: Абхазия
+      Abazin: Апсны
+      Abkhazian: Аԥсны
+      Balkar: Хачыпсы
+      Circassian: Азгъей
+      Karachay: Хачыпсы
+      Kumyk: null
+      Lak: null
+      Nogai: null
+      Ossetian: null
+    regions:
+      Гагрский район:
+        name:
+          English: Gagra District
+          Russian: Гагрийский район
+          Abazin: null
+          Abkhazian: Гагра араион
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+
+  Адыгея:
+    name:
+      English: Adygea
+      Russian: Адыгея
+      Abazin: null
+      Abkhazian: null
+      Balkar: Адыгея
+      Circassian: Адыгей
+      Karachay: Адыгея
+      Kumyk: null
+      Lak: null
+      Nogai: null
+      Ossetian: Адыгей
+    regions:
+      Кошехабльский район:
+        name:
+          English: Koshekhablsky District
+          Russian: Кошехабльский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: Кощхьэблэ къедзыгъо
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Красногвардейский район:
+        name:
+          English: Krasnogvardeysky District
+          Russian: Красногвардейский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: Красногвардейскэ къедзыгъо
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null  
+      Шовгеновский район:
+        name:
+          English: Shovgenovsky District
+          Russian: Шовгеновский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: Шэуджэн къедзыгъо
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+
+  Астраханская область:
+    name:
+      English: Astrakhan Oblast
+      Russian: Астраханская область
+      Abazin: null
+      Abkhazian: null
+      Balkar: null
+      Circassian: Ащтэрхъан област
+      Karachay: null
+      Kumyk: null
+      Lak: null
+      Nogai: Астрахань облысы
+      Ossetian: Астраханы облæст
+    regions:
+      Астрахань:
+        name:
+          English: Astrakhan
+          Russian: Астрахань
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: Ащтэрхъан
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: Астрахань
+          Ossetian: Астрахан
+      Ахтубинский район:
+        name:
+          English: Akhtubinsky District
+          Russian: Ахтубинский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Ахтубинсчы район
+      Володарский район:
+        name:
+          English: Volodarsky District
+          Russian: Володарский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Енотаевский район:
+        name:
+          English: Yenotayevsky District
+          Russian: Енотаевский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Знаменск:
+        name:
+          English: Znamensk
+          Russian: Знаменск
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Знаменск
+      Икрянинский район:
+        name:
+          English: Ikryaninsky District
+          Russian: Икрянинский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null    
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Камызякский район:
+        name:
+          English: Kamyzyaksky District
+          Russian: Камызякский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Красноярский район:
+        name:
+          English: Krasnoyarsky District
+          Russian: Красноярский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Лиманский район:
+        name:
+          English: Limansky District
+          Russian: Лиманский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Наримановский район:
+        name:
+          English: Narimanovsky District
+          Russian: Наримановский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Приволжский район:
+        name:
+          English: Privolzhsky District
+          Russian: Приволжский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Харабалинский район:
+        name:
+          English: Kharabalinsky District
+          Russian: Харабалинский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Черноярский район:
+        name:
+          English: Chernoyarsky District
+          Russian: Черноярский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+
+  Дагестан:
+    name:
+      English: Dagestan
+      Russian: Дагестан
+      Abazin: null
+      Abkhazian: null
+      Balkar: Дагъыстан
+      Circassian: Дагъыстэн
+      Karachay: Дагъыстан
+      Kumyk: Дагъыстан
+      Lak: Дагъусттан
+      Nogai: Дагестан
+      Ossetian: Дагъистан
+    regions:
+      Бабаюртовский район:
+        name:
+          English: Babayurtovsky District
+          Russian: Бабаюртовский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: Баба-юртлу якъ
+          Lak: null
+          Nogai: null
+          Ossetian: Бабаюрты район
+      Буйнакск:
+        name:
+          English: Buynaksk
+          Russian: Буйнакск
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: Бойнакъ
+          Lak: null
+          Nogai: null
+          Ossetian: Буйнаксч
+      Буйнакский район:
+        name:
+          English: Buynaksky District
+          Russian: Буйнакский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: Бойнакъ якъ
+          Lak: null
+          Nogai: null
+          Ossetian: Буйнаксчы район
+      Кизляр:
+        name:
+          English: Kizlyar
+          Russian: Кизляр
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: Къызлар
+          Nogai: Къызлар
+          Ossetian: Хъызлар
+      Кизлярский район:
+        name:
+          English: Kizlyarsky District
+          Russian: Кизлярский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: Къызлар якъ
+          Nogai: Къызлар район
+          Ossetian: Хъызлары район
+      Кизилюрт:
+        name:
+          English: Kizilyurt
+          Russian: Кизилюрт
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: Къызыл-юрт
+          Nogai: Кизилюрт
+          Ossetian: Кизилюрт
+      Кизилюртовский район:
+        name:
+          English: Kizilyurtovsky District
+          Russian: Кизилюртовский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: Къызыл-юртлу якъ
+          Lak: null
+          Nogai: null
+          Ossetian: null
+      Кулинский район:
+        name:
+          English: Kulinsky District
+          Russian: Кулинский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: Ккуллал кӏану
+          Nogai: null
+          Ossetian: Кулийы район
+      Лакский район:
+        name:
+          English: Lakskiy District
+          Russian: Лакский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: Лакку билаят
+          Nogai: null
+          Ossetian: Лакаг район
+      Махачкала:
+        name:
+          English: Makhachkala
+          Russian: Махачкала
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: Махачкъалэ
+          Karachay: null
+          Kumyk: Махачкъала
+          Lak: МахӀачкъала
+          Nogai: null
+          Ossetian: Махачкала
+      Новолакский район:
+        name:
+          English: Novolaksky District
+          Russian: Новолакский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Новолакскоейы район
+      Ногайский район:
+        name:
+          English: Nogaysky District
+          Russian: Ногайский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: Ногъай эл
+          Ossetian: Ногъайы район
+      Табасаранский район:
+        name:
+          English: Tabasaransky District
+          Russian: Табасаранский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Табасараны район
+      Тарумовский район:
+        name:
+          English: Tarumovsky District
+          Russian: Тарумовский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Тарумовкæйы район
+      Хасавюрт:
+        name:
+          English: Khasavyurt
+          Russian: Хасавюрт
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: Хасав-юрт
+          Lak: null
+          Nogai: null
+          Ossetian: Хасавюрт
+      Хасавюртовский район:
+        name:
+          English: Khasavyurtovsky District
+          Russian: Хасавюртовский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: Хасав-юртлу якъ
+          Lak: null
+          Nogai: null
+          Ossetian: Хасавюрты район
+  Кабардино-Балкария:
+    name:
+      English: Kabardino-Balkaria
+      Russian: Кабардино-Балкария
+      Abazin: null
+      Abkhazian: null
+      Balkar: Къабарты-Малкъар
+      Circassian: Къэбэрдей-Балъкъэр
+      Karachay: Къабарты-Малкъар
+      Kumyk: null
+      Lak: null
+      Nogai: null
+      Ossetian: Кæсæг-Балхъар
+    regions:
+      Баксан:
+        name:
+          English: Baksan
+          Russian: Баксан
+          Abazin: null
+          Abkhazian: null
+          Balkar: Басхан
+          Circassian: Бэхъсэн
+          Karachay: Басхан
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Пахсæн
+      Баксанский район:
+        name:
+          English: Baksansky District
+          Russian: Баксанский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: Басхан район
+          Circassian: Бэхъсэн къедзыгъуэ
+          Karachay: Басхан район
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Пахсæны район
+      Зольский район:
+        name:
+          English: Zolsky District
+          Russian: Дзэлыкъуэ къедзыгъуэ
+          Abazin: null
+          Abkhazian: null
+          Balkar: Зольск район
+          Circassian: Дзэлыкъуэ къедзыгъуэ
+          Karachay: Зольск район
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Золкæйы район
+      Лескенский район:
+        name:
+          English: Leskensky District
+          Russian: Лескенский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: Лескен район[
+          Circassian: Лэскэн къедзыгъуэ
+          Karachay: Лескен район
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Лескены район
+      Майский район:
+        name:
+          English: Maysky District
+          Russian: Майский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: Май район
+          Circassian: Майскэ къедзыгъуэ
+          Karachay: Май район
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Майскийы район
+      Нальчик:
+        name:
+          English: Nalchik
+          Russian: Нальчик
+          Abazin: null
+          Abkhazian: null
+          Balkar: Налчыкъ
+          Circassian: Налшык
+          Karachay: Налчыкъ
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Налцыкк
+      Прохладный:
+        name:
+          English: Prokhladny
+          Russian: Прохладный
+          Abazin: null
+          Abkhazian: null
+          Balkar: Прохладна
+          Circassian: Прохладнэ
+          Karachay: Прохладна
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Прохладнæ
+      Прохладный район:
+        name:
+          English: Prokhladnensky District
+          Russian: Прохладненский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: Прохладна район
+          Circassian: Прохладнэ къедзыгъуэ
+          Karachay: Прохладна район
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Прохладнæйы район
+      Терский район:
+        name:
+          English: Tersky District
+          Russian: Терский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: Терк район
+          Circassian: Тэрч къедзыгъуэ
+          Karachay: Терк район
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Терчы район
+      Урванский район:
+        name:
+          English: Urvansky District
+          Russian: Урванский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: Урван район
+          Circassian: Аруан къедзыгъуэ
+          Karachay: Урван район
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Æруаны район
+      Чегемский район:
+        name:
+          English: Chegemsky District
+          Russian: Чегемский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: Чегем район
+          Circassian: Шэджэм къедзыгъуэ
+          Karachay: Чегем район
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Чегемы район
+      Черекский район:
+        name:
+          English: Chereksky District
+          Russian: Черекский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: Черек район
+          Circassian: Шэрэдж къедзыгъуэ
+          Karachay: Черек район
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Цæрæчы район
+      Эльбрусский район:
+        name:
+          English: Elbrussky District
+          Russian: Эльбрусский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: Эльбрус район
+          Circassian: Ӏуащхьэмахуэ къедзыгъуэ
+          Karachay: Эльбрус район
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Эльбрусы район
+
+  Карачаево-Черкесия:
+    name:
+      English: Karachay-Cherkessia
+      Russian: Карачаево-Черкесия
+      Abazin: Къарча-Черкес
+      Abkhazian: null
+      Balkar: null
+      Circassian: Къэрэшей-Адыгэ
+      Karachay: null
+      Kumyk: null
+      Lak: null
+      Nogai: null
+      Ossetian: null
+    regions:
+      Абазинский район:
+        name:
+          English: Abazinsky District
+          Russian: Абазинский район
+          Abazin: Абаза район
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null   
+      Хабезский район:
+        name:
+          English: Khabez District
+          Russian: Хабезский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: Хьэбэз къедзыгъуэ
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+
+  Краснодарский край:
+    name:
+      English: Krasnodar Krai
+      Russian: Краснодарский край
+      Abazin: Краснодар шта
+      Abkhazian: null
+      Balkar: null
+      Circassian: null
+      Karachay: null
+      Kumyk: null
+      Lak: null
+      Nogai: null
+      Ossetian: null
+    regions:
+      Адлерский район:
+        name:
+          English: Adler District
+          Russian: Адлерский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: null
+
+  Крым:
+    name:
+      English: Crimea
+      Russian: Крым
+      Abazin: Крым
+      Abkhazian: Ҟрым
+      Balkar: Кърым
+      Circassian: Кърым
+      Karachay: Кърым
+      Kumyk: null
+      Lak: null
+      Nogai: Къырым
+      Ossetian: Хъырым
+    regions:
+      Симферополь:
+        name:
+          English: Simferopol
+          Russian: Симферополь
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Симферополь
+
+  Северная Осетия:
+    name:
+      English: North Ossetia
+      Russian: Северная Осетия
+      Abazin: null
+      Abkhazian: null
+      Balkar: Шимал Тегей
+      Circassian: Ищхъэрэ Ӏэсетиэ
+      Karachay: Шимал Тегей
+      Kumyk: null
+      Lak: null
+      Nogai: null
+      Ossetian: Цӕгат Ирыстон
+    regions:
+      Владикавказ:
+        name:
+          English: Vladikavkaz
+          Russian: Владикавказ
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Дзӕуджыхъӕу
+      Моздокский район:
+        name:
+          English: Mozdoksky District
+          Russian: Моздокский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: Мэздэгу къедзыгъуэ
+          Karachay: null
+          Kumyk: Моздок район
+          Lak: null
+          Nogai: null
+          Ossetian: Мӕздӕджы район
+
+  Ставропольский край:
+    name:
+      English: Stavropol Krai
+      Russian: Ставропольский край
+      Abazin: Ставрополь край
+      Abkhazian: Ставрополь край
+      Balkar: Ставрополь край
+      Circassian: Ставропол край
+      Karachay: Ставрополь край
+      Kumyk: null
+      Lak: null
+      Nogai: Ставрополь крайы
+      Ossetian: Стъараполы край
+    regions:
+      Ставрополь:
+        name:
+          English: Stavropol
+          Russian: Ставрополь
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: Шъэт-Къалэ
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: Ставрополь
+          Ossetian: Стъарапол
+
+  Южная Осетия:
+    name:
+      English: South Ossetia
+      Russian: Южная Осетия
+      Abazin: null
+      Abkhazian: Аахыҵ Уаԥстәыла
+      Balkar: Къыбыла Тегей
+      Circassian: Ипшэ Ӏэсетиэ
+      Karachay: Къыбыла Тегей
+      Kumyk: null
+      Lak: Кьилвалул Осетия
+      Nogai: null
+      Ossetian: Хуссар Ирыстон
+    regions:
+      Цхинвал:
+        name:
+          English: Tskhinval
+          Russian: Цхинвал
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Цхинвал
+      Цхинвальский район:
+        name:
+          English: Tskhinval District
+          Russian: Цхинвальский район
+          Abazin: null
+          Abkhazian: null
+          Balkar: null
+          Circassian: null
+          Karachay: null
+          Kumyk: null
+          Lak: null
+          Nogai: null
+          Ossetian: Цхинвалы район
+          

--- a/config/mapping-locations.yaml
+++ b/config/mapping-locations.yaml
@@ -547,7 +547,7 @@ states:
           Russian: Лескенский район
           Abazin: null
           Abkhazian: null
-          Balkar: Лескен район[
+          Balkar: Лескен район
           Circassian: Лэскэн къедзыгъуэ
           Karachay: Лескен район
           Kumyk: null

--- a/config/mapping-locations.yaml
+++ b/config/mapping-locations.yaml
@@ -20,7 +20,7 @@ states:
       Гагрский район:
         name:
           English: Gagra District
-          Russian: Гагрийский район
+          Russian: Гагрский район
           Abazin: null
           Abkhazian: Гагра араион
           Balkar: null

--- a/config/mapping-locations.yaml
+++ b/config/mapping-locations.yaml
@@ -531,7 +531,7 @@ states:
       Зольский район:
         name:
           English: Zolsky District
-          Russian: Дзэлыкъуэ къедзыгъуэ
+          Russian: Зольский район
           Abazin: null
           Abkhazian: null
           Balkar: Зольск район

--- a/config/mapping-villages.yaml
+++ b/config/mapping-villages.yaml
@@ -223,7 +223,7 @@ states:
           Белая речка:
       Чегемский район:
         villages:
-          Чегем Первый:
+          Чегем I:
             name:
               English: Chegem I
               Russian: Чегем I
@@ -239,7 +239,7 @@ states:
             coordinates:
               Latitude: 43.570380
               Longitude: 43.586725
-          Чегем Второй:
+          Чегем II:
             name:
               English: Chegem II
               Russian: Чегем II

--- a/config/mapping-villages.yaml
+++ b/config/mapping-villages.yaml
@@ -31,7 +31,7 @@ states:
         villages:
           Красногвардейское:
             name:
-              English: Krasnogvardeyskое
+              English: Krasnogvardeyskoye
               Russian: Красногвардейское
               Abazin: null
               Abkhazian: null

--- a/config/mapping-villages.yaml
+++ b/config/mapping-villages.yaml
@@ -1,0 +1,383 @@
+# Village-level mapping of names across languages
+# Hierarchical structure: states → regions → villages
+# Use this for quick lookup and coordinate resolution
+
+states:
+
+  Абхазия:
+    regions:
+      Гагрский район:
+        villages:
+          Цандрыпш:
+            name:
+              English: Tsandrypsh
+              Russian: Цандрыпш
+              Abazin: null
+              Abkhazian: Цандрыԥшь
+              Balkar: null
+              Circassian: null
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.382394
+              Longitude: 40.081175
+
+  Адыгея:
+    regions:
+      Красногвардейский район:
+        villages:
+          Красногвардейское:
+            name:
+              English: Krasnogvardeyskое
+              Russian: Красногвардейское
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Красногвардейскэ къедзыгъо
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 45.143718
+              Longitude: 39.589635
+          Бжедугхабль:
+            name:
+              English: Bzhedugkhabl
+              Russian: Бжедугхабль
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Бжъэдыгъухьабл
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 44.966667
+              Longitude: 39.7
+      Кошехабльский район:
+        villages:
+          Кошехабль:
+            name:
+              English: Koshekhabl
+              Russian: Кошехабль
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Андзаурий
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 44.900124
+              Longitude: 40.502889
+      Шовгеновский район:
+        villages:
+          Хатажукай:
+            name:
+              English: Khatazhukay
+              Russian: Хатажукай
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Хьатыгъужъыкъуай
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 45.070575
+              Longitude: 40.185999
+          Хакуринохабль:
+            name:
+              English: Khakurinokhabl
+              Russian: Хакуринохабль
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Хьэкурынэхьабл
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 45.019271
+              Longitude: 40.23635
+  Кабардино-Балкария:
+    regions:
+      Баксанский район:
+        villages:
+          Исламей:
+            name:
+              English: Islamey
+              Russian: Исламей
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Ислъэмей
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.673209
+              Longitude: 43.457385
+          Нижний Куркужин:
+            name:
+              English: Nizhniy Kurkuzhin
+              Russian: Нижний Куркужин
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Къуэн хьэблэ
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.729825
+              Longitude: 43.339895
+      Зольский район:
+        villages:
+          Малка:
+            name:
+              English: Malka
+              Russian: Малка
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Хьэжы хьэблэ
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.799173
+              Longitude: 43.326716
+      Лексенский район:
+        villages:
+          Кугулыкъуей:
+            name:
+              English: Urukh
+              Russian: Урух
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Къугъулыкъуей
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.292826
+              Longitude: 44.027438
+          Анзорей:
+            name:
+              English: Anzorey
+              Russian: Анзорей
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Андзорей
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.354561
+              Longitude: 43.940041
+      Нальчик:
+        villages:
+          Кенже:
+            name:
+              English: Kenzhe
+              Russian: Кенже
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Къуэшрыкъуей
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.496874
+              Longitude: 43.553101
+          Хасанья:
+          Белая речка:
+      Чегемский район:
+        villages:
+          Чегем Первый:
+            name:
+              English: Chegem I
+              Russian: Чегем I
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Къундетей I
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.570380
+              Longitude: 43.586725
+          Чегем Второй:
+            name:
+              English: Chegem II
+              Russian: Чегем II
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Къундетей II
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.592575
+              Longitude: 43.596588
+      Черекский район:
+        villages:
+          Жемтала:
+            name:
+              English: Zhemtala
+              Russian: Жемтала
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Къуэжыкъуей
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.282963
+              Longitude: 43.656497
+      Прохладный район:
+        villages:
+          Карагач:
+            name:
+              English: Karagach
+              Russian: Карагач
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Инал хьэблэ
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.804488
+              Longitude: 43.774176
+  Карачаево-Черкесия:
+    regions:
+      Абазинский район:
+        villages:
+          Псыж:
+            name:
+              English: Psyzh
+              Russian: Псыж
+              Abazin: Псыжв
+              Abkhazian: null
+              Balkar: Псыж
+              Circassian: Псыжъ
+              Karachay: Псыж
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 44.235040
+              Longitude: 42.015787
+          Эльбурган:
+            name:
+              English: Elburgan
+              Russian: Эльбурган
+              Abazin: Бибаркт
+              Abkhazian: null
+              Balkar: null
+              Circassian: Елбыргъан
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 44.079395
+              Longitude: 41.798098
+      Хабезский район:
+        villages:
+          Малый Зеленчук:
+            name:
+              English: Maly Zelenchuk
+              Russian: Малый Зеленчук
+              Abazin: null
+              Abkhazian: null
+              Balkar: null
+              Circassian: Ботэщей
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 44.163584
+              Longitude: 41.865741
+          Хабез:
+            name:
+              English: Khabez
+              Russian: Хабез
+              Abazin: null
+              Abkhazian: null             
+              Balkar: null
+              Circassian: Къэсейхьэблэ
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 44.043204
+              Longitude: 41.766657
+  Краснодарский край:
+    regions:
+      Адлерский район:
+        villages:
+          Аибга:
+            name:
+              English: Aibga
+              Russian: Аибга
+              Abazin: null
+              Abkhazian: А́ибӷа
+              Balkar: null
+              Circassian: null
+              Karachay: null
+              Kumyk: null
+              Lak: null
+              Nogai: null
+              Ossetian: null
+            coordinates:
+              Latitude: 43.587784
+              Longitude: 40.19439

--- a/config/mapping-villages.yaml
+++ b/config/mapping-villages.yaml
@@ -169,7 +169,7 @@ states:
               Longitude: 43.326716
       Лексенский район:
         villages:
-          Кугулыкъуей:
+          Урух:
             name:
               English: Urukh
               Russian: Урух

--- a/index.html
+++ b/index.html
@@ -28,6 +28,9 @@
     <!-- Chart.js for Statistics -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 
+    <!-- js-yaml for YAML parsing -->
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏔️</text></svg>">
 

--- a/index.html
+++ b/index.html
@@ -26,10 +26,14 @@
             crossorigin=""></script>
 
     <!-- Chart.js for Statistics -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+            integrity="sha256-0q+JdOlScWOHcunpUk21uab1jW7C1deBQARHtKMcaB4="
+            crossorigin="anonymous"></script>
 
     <!-- js-yaml for YAML parsing -->
-    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"
+            integrity="sha512-CSBhVREyzHAjAFfBlIBakjoRUKp5h7VSweP0InR/pAJyptH7peuhCsqAI/snV+TwZmXZqoUklpXp6R6wMnYf5Q=="
+            crossorigin="anonymous"></script>
 
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏔️</text></svg>">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circassiandna-heritage",
-  "version": "1.0.0",
+  "version": "4.0.0",
   "description": "Circassian DNA Heritage Feed",
   "scripts": {
     "start": "python3 -m http.server 8000",


### PR DESCRIPTION
## feat: centralize translations & simplify JSON schema (v3)

### Summary
Removes all repetitive native/English translations and coordinates from individual family JSON records. These are now resolved at runtime from three centralized YAML config files, making each family record significantly smaller and easier to maintain.

---

### Changes

#### New config files (`config/`)
- **`mapping-ethnicities.yaml`** — Russian, native, and gendered translations for all main ethnicities and sub-groups
- **`mapping-villages.yaml`** — Hierarchical `state → region → village` lookup with per-ethnicity native names and coordinates for all 21+ villages
- **`mapping-locations.yaml`** — State and region names per ethnicity across 11 states (Адыгея, КБР, КЧР, Абхазия, Крым, etc.)

#### `assets/js/data-loader.js`
- Loads all 3 YAML configs in parallel on startup
- Builds flat indexes (`villageIndex`, `stateIndex`, `regionIndex`) for O(1) lookup
- `enrichFamilyData()` rewritten: expands Russian-only JSON location strings into full `{russian, native, english}` objects + injects coordinates — all keyed by the family's own ethnicity so each person sees their own language's place name
- Ethnicity enrichment updated to use `mapping-ethnicities.yaml`

#### `assets/js/maps.js`
- `getVillageName()` priority changed to `native → russian → english` so Circassian/Abazin/etc. families display their own village name first

#### Data files
- All 7 ethnic JSONs migrated to **schema v3**: English-only ethnicity fields, Russian-only location strings, no embedded coordinates
- `heritage-data.json` regenerated (38 families)
- `heritage-data-template.json` updated to reflect v3 schema
- `heritage-data-manifest.json` — Circassian count corrected (12 → 18), Nogai confirmed

#### Cleanup
- Removed one-time migration scripts (`migrate-location-structure.py`, `refactor-ethnicity-to-english-only.py`)
- Removed obsolete `ethnicity-mapping.yaml` (superseded by `mapping-ethnicities.yaml`)

---

### Before / After (per family record)

**Before** — location block: ~20 lines, coordinates + 3 languages × 3 fields × 3 levels
**After** — location block: 6 lines, Russian key only; everything else resolved at runtime
