### PR TITLE
feat/stats

### DIFF
--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -452,19 +452,15 @@
         overflow: hidden;
     }
     
-    .chart-container {
+    .chart-canvas-wrap {
         max-width: 100%;
         width: 100%;
         overflow: hidden;
-        transform: scale(0.90);
-        transform-origin: center top;
-        margin-bottom: -20px;
     }
     
-    .chart-container canvas {
+    .chart-canvas-wrap canvas {
         max-width: 100% !important;
         width: 100% !important;
-        height: auto !important;
     }
     
     /* Mobile card improvements */

--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -189,8 +189,7 @@
     }
     
     /* Dropdown menu improvements for mobile */
-    .dropdown-menu,
-    .ethnicity-options {
+    .custom-options {
         max-height: 450px !important;
         width: 100% !important;
         max-width: 100% !important;
@@ -270,14 +269,14 @@
         text-align: center !important;
     }
     
-    /* Ethnicity options */
-    .ethnicity-options {
+    /* Ethnicity options — actual rendered classes from main.js */
+    .custom-options {
         display: flex !important;
         flex-direction: column !important;
         gap: 4px !important;
     }
     
-    .ethnicity-option {
+    .custom-option {
         display: flex !important;
         align-items: center !important;
         gap: 12px !important;
@@ -287,12 +286,12 @@
         transition: all 0.2s ease !important;
     }
     
-    .ethnicity-option:hover,
-    .ethnicity-option:active {
+    .custom-option:hover,
+    .custom-option:active {
         background: var(--bg-light) !important;
     }
     
-    .ethnicity-flag {
+    .option-flag {
         width: 32px !important;
         height: 32px !important;
         min-width: 32px !important;
@@ -300,7 +299,7 @@
         border-radius: 6px !important;
     }
     
-    .ethnicity-name {
+    .option-text {
         flex: 1 !important;
         font-size: 1rem !important;
         font-weight: 500 !important;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -458,6 +458,7 @@ body {
     align-items: center;
     gap: 6px;
     width: 100%;
+    box-sizing: border-box;
     background: none;
     border: none;
     padding: 4px 6px;
@@ -484,6 +485,7 @@ body {
 
 .sub-ethnicity-legend .legend-chevron {
     margin-left: auto;
+    flex-shrink: 0;
     font-size: 0.65rem;
     transition: transform 0.2s;
     color: var(--text-secondary);

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -418,7 +418,14 @@ body {
 }
 
 .chart-card canvas {
-    max-height: 300px;
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.chart-canvas-wrap {
+    position: relative;
+    height: 300px;
 }
 
 .chart-stats {
@@ -430,10 +437,6 @@ body {
 }
 
 /* Sub-Ethnicity: donut left, collapsible legend right — mirrors Ethnicity layout */
-#subEthnicityChart {
-    max-height: 300px;
-}
-
 .sub-ethnicity-wrap {
     display: flex;
     align-items: flex-start;
@@ -443,6 +446,7 @@ body {
 .sub-ethnicity-chart-container {
     flex: 1 1 auto;
     min-width: 0;
+    height: 300px;
 }
 
 .sub-ethnicity-legend {
@@ -549,6 +553,17 @@ body {
 
     .charts-grid .chart-card {
         grid-column: 1 / -1;
+    }
+
+    /* Stack sub-ethnicity chart above legend on mobile */
+    .sub-ethnicity-wrap {
+        flex-direction: column;
+    }
+
+    .sub-ethnicity-legend {
+        flex: none;
+        width: 100%;
+        max-height: 160px;
     }
     
     .chart-card.full-width {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -441,13 +441,13 @@ body {
 }
 
 .sub-ethnicity-chart-container {
-    flex: 0 0 55%;
+    flex: 1 1 auto;
     min-width: 0;
 }
 
 .sub-ethnicity-legend {
-    flex: 1;
-    min-width: 0;
+    flex: 0 0 130px;
+    width: 130px;
     padding-top: 4px;
     max-height: 300px;
     overflow-y: auto;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -429,6 +429,54 @@ body {
     color: var(--text-secondary);
 }
 
+/* Sub-Ethnicity chart: donut left, grouped legend right */
+.sub-ethnicity-wrap {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.sub-ethnicity-wrap canvas {
+    flex: 0 0 auto;
+    max-width: 240px;
+    max-height: 240px !important;
+}
+
+.sub-ethnicity-legend {
+    flex: 1;
+    overflow-y: auto;
+    max-height: 260px;
+}
+
+.sub-ethnicity-legend .legend-group {
+    margin-bottom: 10px;
+}
+
+.sub-ethnicity-legend .legend-parent {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    margin-bottom: 3px;
+}
+
+.sub-ethnicity-legend .legend-color {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+
+.sub-ethnicity-legend .legend-sub {
+    padding-left: 18px;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    line-height: 1.8;
+}
+
 /* Responsive tabs */
 @media (max-width: 768px) {
     .tab-label {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -429,16 +429,27 @@ body {
     color: var(--text-secondary);
 }
 
-/* Sub-Ethnicity collapsible legend */
+/* Sub-Ethnicity: donut left, collapsible legend right — mirrors Ethnicity layout */
 #subEthnicityChart {
-    max-height: 200px !important;
+    max-height: 300px;
+}
+
+.sub-ethnicity-wrap {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.sub-ethnicity-chart-container {
+    flex: 0 0 55%;
+    min-width: 0;
 }
 
 .sub-ethnicity-legend {
-    margin-top: 10px;
-    border-top: 1px solid var(--border-light);
-    padding-top: 6px;
-    max-height: 110px;
+    flex: 1;
+    min-width: 0;
+    padding-top: 4px;
+    max-height: 300px;
     overflow-y: auto;
 }
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -439,7 +439,7 @@ body {
 /* Sub-Ethnicity: donut left, collapsible legend right — mirrors Ethnicity layout */
 .sub-ethnicity-wrap {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 16px;
 }
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -465,6 +465,7 @@ body {
     border-radius: 4px;
     cursor: pointer;
     font-size: 0.82rem;
+    line-height: 1;
     font-weight: 600;
     color: var(--text-primary);
     text-align: left;
@@ -486,13 +487,21 @@ body {
 .sub-ethnicity-legend .legend-chevron {
     margin-left: auto;
     flex-shrink: 0;
-    font-size: 0.65rem;
+    align-self: center;
+    line-height: 1;
+    font-size: 0.6rem;
     transition: transform 0.2s;
     color: var(--text-secondary);
 }
 
 .sub-ethnicity-legend .legend-group.open .legend-chevron {
     transform: rotate(180deg);
+}
+
+.sub-ethnicity-legend .legend-count {
+    font-weight: 400;
+    color: var(--text-secondary);
+    line-height: 1;
 }
 
 .sub-ethnicity-legend .legend-subs {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -429,52 +429,73 @@ body {
     color: var(--text-secondary);
 }
 
-/* Sub-Ethnicity chart: donut left, grouped legend right */
-.sub-ethnicity-wrap {
-    display: flex;
-    align-items: flex-start;
-    gap: 16px;
-}
-
-.sub-ethnicity-wrap canvas {
-    flex: 0 0 auto;
-    max-width: 240px;
-    max-height: 240px !important;
-}
-
+/* Sub-Ethnicity collapsible legend */
 .sub-ethnicity-legend {
-    flex: 1;
-    overflow-y: auto;
-    max-height: 260px;
+    margin-top: 12px;
+    border-top: 1px solid var(--border-light);
+    padding-top: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
 }
 
 .sub-ethnicity-legend .legend-group {
-    margin-bottom: 10px;
+    width: 100%;
 }
 
-.sub-ethnicity-legend .legend-parent {
+.sub-ethnicity-legend .legend-toggle {
     display: flex;
     align-items: center;
     gap: 6px;
+    width: 100%;
+    background: none;
+    border: none;
+    padding: 4px 6px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.82rem;
     font-weight: 600;
-    font-size: 0.85rem;
     color: var(--text-primary);
-    margin-bottom: 3px;
+    text-align: left;
+    transition: background 0.15s;
+}
+
+.sub-ethnicity-legend .legend-toggle:hover {
+    background: var(--bg-light);
 }
 
 .sub-ethnicity-legend .legend-color {
     display: inline-block;
-    width: 12px;
-    height: 12px;
+    width: 11px;
+    height: 11px;
     border-radius: 2px;
     flex-shrink: 0;
 }
 
-.sub-ethnicity-legend .legend-sub {
-    padding-left: 18px;
+.sub-ethnicity-legend .legend-chevron {
+    margin-left: auto;
+    font-size: 0.65rem;
+    transition: transform 0.2s;
+    color: var(--text-secondary);
+}
+
+.sub-ethnicity-legend .legend-group.open .legend-chevron {
+    transform: rotate(180deg);
+}
+
+.sub-ethnicity-legend .legend-subs {
+    display: none;
+    padding: 2px 0 6px 24px;
+}
+
+.sub-ethnicity-legend .legend-group.open .legend-subs {
+    display: block;
+}
+
+.sub-ethnicity-legend .legend-sub-row {
     font-size: 0.75rem;
     color: var(--text-secondary);
-    line-height: 1.8;
+    line-height: 1.9;
 }
 
 /* Responsive tabs */
@@ -503,6 +524,10 @@ body {
     
     .charts-grid {
         grid-template-columns: 1fr;
+    }
+
+    .charts-grid .chart-card {
+        grid-column: 1 / -1;
     }
     
     .chart-card.full-width {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1288,8 +1288,8 @@ body {
 }
 
 .action-btn.y-dna-btn.tree-group {
-    background: #90EE90 !important;  /* Light green */
-    color: #2c3e50 !important;  /* Darker text for contrast */
+    background: #90EE90 !important;  /* Light green — contrast vs #2c3e50: ~7.1:1 (WCAG AA ✓) */
+    color: #2c3e50 !important;
 }
 
 /* Tree button color variations for mtDNA (females) */
@@ -1302,8 +1302,8 @@ body {
 }
 
 .action-btn.mt-dna-btn.tree-group {
-    background: #ADD8E6 !important;  /* Light blue */
-    color: #2c3e50 !important;  /* Darker text for contrast */
+    background: #ADD8E6 !important;  /* Light blue — contrast vs #2c3e50: ~6.8:1 (WCAG AA ✓) */
+    color: #2c3e50 !important;
 }
 
 .action-btn.secondary {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -444,6 +444,7 @@ body {
 }
 
 .sub-ethnicity-chart-container {
+    position: relative;
     flex: 1 1 auto;
     min-width: 0;
     height: 300px;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -430,17 +430,16 @@ body {
 }
 
 /* Sub-Ethnicity collapsible legend */
-.sub-ethnicity-legend {
-    margin-top: 12px;
-    border-top: 1px solid var(--border-light);
-    padding-top: 8px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
+#subEthnicityChart {
+    max-height: 200px !important;
 }
 
-.sub-ethnicity-legend .legend-group {
-    width: 100%;
+.sub-ethnicity-legend {
+    margin-top: 10px;
+    border-top: 1px solid var(--border-light);
+    padding-top: 6px;
+    max-height: 110px;
+    overflow-y: auto;
 }
 
 .sub-ethnicity-legend .legend-toggle {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -352,11 +352,15 @@ class HeritageApp {
             });
         });
         
-        // Close dropdown when clicking outside
-        document.addEventListener('click', () => {
+        // Close dropdown when clicking outside — store reference to avoid duplicate listeners
+        if (this._dropdownClickHandler) {
+            document.removeEventListener('click', this._dropdownClickHandler);
+        }
+        this._dropdownClickHandler = () => {
             customSelect.classList.remove('active');
             customOptions.classList.remove('active');
-        });
+        };
+        document.addEventListener('click', this._dropdownClickHandler);
     }
     
     /**

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -587,9 +587,11 @@ class HeritageApp {
         states.forEach(state => {
             const isChecked = this.selectedStates?.includes(state) ? 'checked' : '';
             const displayName = this.getLocationDisplayName(state);
-            optionsHTML += `<div class="location-option" data-value="state:${state}" data-type="state">
-                <input type="checkbox" class="location-checkbox" data-location="${state}" data-type="state" ${isChecked}>
-                <span>${displayName}</span>
+            const safeState       = this.escapeHtml(state);
+            const safeDisplayName = this.escapeHtml(displayName);
+            optionsHTML += `<div class="location-option" data-value="state:${safeState}" data-type="state">
+                <input type="checkbox" class="location-checkbox" data-location="${safeState}" data-type="state" ${isChecked}>
+                <span>${safeDisplayName}</span>
             </div>`;
         });
         optionsHTML += '</div>';
@@ -599,9 +601,10 @@ class HeritageApp {
         optionsHTML += '<div class="location-column-header">Village</div>';
         villages.forEach(village => {
             const isChecked = this.selectedVillages?.includes(village) ? 'checked' : '';
-            optionsHTML += `<div class="location-option" data-value="village:${village}" data-type="village">
-                <input type="checkbox" class="location-checkbox" data-location="${village}" data-type="village" ${isChecked}>
-                <span>${village}</span>
+            const safeVillage = this.escapeHtml(village);
+            optionsHTML += `<div class="location-option" data-value="village:${safeVillage}" data-type="village">
+                <input type="checkbox" class="location-checkbox" data-location="${safeVillage}" data-type="village" ${isChecked}>
+                <span>${safeVillage}</span>
             </div>`;
         });
         optionsHTML += '</div>';
@@ -699,7 +702,7 @@ class HeritageApp {
         
         const parts = [];
         if (this.selectedStates.length > 0) {
-            parts.push(...this.selectedStates);
+            parts.push(...this.selectedStates.map(s => this.getLocationDisplayName(s)));
         }
         if (this.selectedVillages.length > 0) {
             parts.push(...this.selectedVillages);

--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -648,14 +648,11 @@ class HeritageMaps {
             maxZoom: 19
         }).addTo(this.maps.mtdna);
 
-        // mtDNA data will be incorporated later
-        const legend = document.getElementById('mtdnaLegend');
-        if (legend) {
-            legend.innerHTML = `
-                <strong>mtDNA Distribution</strong><br>
-                <span style="font-size: 0.85rem; color: var(--text-secondary);">Data coming soon...</span>
-            `;
-        }
+        // Display mtDNA data
+        this.updateDNADistribution('mtdna', this.maps.mtdna, 'mtdnaLegend');
+
+        // Leaflet needs a repaint frame after display:none→block to measure the container correctly
+        setTimeout(() => this.maps.mtdna?.invalidateSize(), 0);
     }
 
     /**

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -693,37 +693,29 @@ class HeritageStatistics {
         if (!ctx) return;
 
         const items  = this.getSubEthnicityDistribution();
-        // Legend label: "1. Kabardian", "2. Shapsough" etc.
-        const labels = items.map(i => `${i.rank}. ${i.label}`);
         const data   = items.map(i => i.count);
         const colors = this.getSubEthnicityColors(items);
-        // Store ranks in dataset for the inline label plugin
         const ranks  = items.map(i => i.rank);
+        // Plain labels for tooltip (no rank prefix — we use the custom HTML legend)
+        const labels = items.map(i => i.label);
 
-        // Inline plugin: draw rank number in the middle of each arc.
-        // No external dependency — uses the Chart.js afterDatasetsDraw hook.
         const rankLabelPlugin = {
             id: 'subEthnicityRankLabels',
             afterDatasetsDraw(chart) {
-                const { ctx: c, chartArea } = chart;
+                const { ctx: c } = chart;
                 const meta = chart.getDatasetMeta(0);
                 const ds   = chart.data.datasets[0];
-                const total = ds.data.reduce((a, b) => a + b, 0);
 
                 meta.data.forEach((arc, index) => {
-                    // Skip slices narrower than ~8° — number won't fit
-                    const sliceAngle = arc.endAngle - arc.startAngle;
-                    if (sliceAngle < 0.14) return;
-
+                    if (arc.endAngle - arc.startAngle < 0.14) return;
                     const midAngle  = (arc.startAngle + arc.endAngle) / 2;
                     const midRadius = (arc.innerRadius + arc.outerRadius) / 2;
                     const x = arc.x + midRadius * Math.cos(midAngle);
                     const y = arc.y + midRadius * Math.sin(midAngle);
-
                     c.save();
-                    c.font        = 'bold 11px sans-serif';
-                    c.fillStyle   = '#ffffff';
-                    c.textAlign   = 'center';
+                    c.font = 'bold 11px sans-serif';
+                    c.fillStyle = '#ffffff';
+                    c.textAlign = 'center';
                     c.textBaseline = 'middle';
                     c.fillText(ds.ranks[index], x, y);
                     c.restore();
@@ -736,28 +728,17 @@ class HeritageStatistics {
             plugins: [rankLabelPlugin],
             data: {
                 labels,
-                datasets: [{
-                    data,
-                    ranks,   // consumed by rankLabelPlugin
-                    backgroundColor: colors,
-                    borderWidth: 2,
-                    borderColor: '#fff'
-                }]
+                datasets: [{ data, ranks, backgroundColor: colors, borderWidth: 2, borderColor: '#fff' }]
             },
             options: {
                 responsive: true,
                 maintainAspectRatio: true,
                 plugins: {
-                    legend: {
-                        position: 'right',
-                        labels: { padding: 10, font: { size: 12 } }
-                    },
+                    legend: { display: false },
                     tooltip: {
                         callbacks: {
                             label: function(context) {
-                                // Strip the rank prefix from the display label in tooltip
-                                const raw   = context.label || '';
-                                const label = raw.replace(/^\d+\.\s*/, '');
+                                const label = context.label || '';
                                 const value = context.parsed || 0;
                                 const total = context.dataset.data.reduce((a, b) => a + b, 0);
                                 const pct   = ((value / total) * 100).toFixed(1);
@@ -768,6 +749,44 @@ class HeritageStatistics {
                 }
             }
         });
+
+        this._renderSubEthnicityLegend(items);
+    }
+
+    /**
+     * Build the custom grouped HTML legend for the sub-ethnicity chart.
+     * Groups sub-ethnicities under their parent ethnicity heading.
+     * @param {Array<{label,parent,count,rank}>} items
+     */
+    _renderSubEthnicityLegend(items) {
+        const container = document.getElementById('subEthnicityLegend');
+        if (!container) return;
+
+        // Group items by parent in order they appear
+        const groups = [];
+        const seen   = {};
+        items.forEach(item => {
+            if (!seen[item.parent]) {
+                seen[item.parent] = [];
+                groups.push({ parent: item.parent, subs: seen[item.parent] });
+            }
+            seen[item.parent].push(item);
+        });
+
+        container.innerHTML = groups.map(({ parent, subs }) => {
+            const color = HaplotypeConfig.getEthnicityColor(parent);
+            const subRows = subs.map(s =>
+                `<div class="legend-sub">${s.rank} &ndash; ${s.label}</div>`
+            ).join('');
+            return `
+                <div class="legend-group">
+                    <div class="legend-parent">
+                        <span class="legend-color" style="background:${color}"></span>
+                        ${parent}
+                    </div>
+                    ${subRows}
+                </div>`;
+        }).join('');
     }
 
     /**
@@ -950,11 +969,12 @@ class HeritageStatistics {
      */
     updateSubEthnicityChart() {
         const items = this.getSubEthnicityDistribution();
-        this.charts.subEthnicity.data.labels                      = items.map(i => `${i.rank}. ${i.label}`);
+        this.charts.subEthnicity.data.labels                      = items.map(i => i.label);
         this.charts.subEthnicity.data.datasets[0].data             = items.map(i => i.count);
         this.charts.subEthnicity.data.datasets[0].ranks            = items.map(i => i.rank);
         this.charts.subEthnicity.data.datasets[0].backgroundColor  = this.getSubEthnicityColors(items);
         this.charts.subEthnicity.update();
+        this._renderSubEthnicityLegend(items);
     }
 
     /**

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -301,7 +301,7 @@ class HeritageStatistics {
 
     /**
      * Get sub-ethnicity distribution grouped by parent ethnicity.
-     * Returns an array of {label, parent, count} sorted by parent total (desc)
+     * Returns an array of {label, parent, count, rank} sorted by parent total (desc)
      * then by sub-ethnicity count (desc) within each group.
      */
     getSubEthnicityDistribution() {
@@ -366,7 +366,15 @@ class HeritageStatistics {
      * @returns {Array<string>}
      */
     getSubEthnicityColors(items) {
-        return items.map(({ parent }) => HaplotypeConfig.getEthnicityColor(parent));
+        // Build a unique-parent index so unknown parents each get a distinct generated colour
+        const parentIndex = {};
+        let nextIdx = 0;
+        items.forEach(({ parent }) => {
+            if (!(parent in parentIndex)) parentIndex[parent] = nextIdx++;
+        });
+        return items.map(({ parent }) =>
+            HaplotypeConfig.getEthnicityColor(parent, parentIndex[parent])
+        );
     }
 
     /**

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -846,8 +846,8 @@ class HeritageStatistics {
                 datasets: [{
                     label: 'Families',
                     data: data,
-                    backgroundColor: '#477571',
-                    borderColor: '#3b5f5b',
+                    backgroundColor: '#DCD3C3',
+                    borderColor: '#a8a097',
                     borderWidth: 1
                 }]
             },
@@ -890,8 +890,8 @@ class HeritageStatistics {
                 datasets: [{
                     label: 'Families',
                     data: data,
-                    backgroundColor: '#154341',
-                    borderColor: '#0e2e2c',
+                    backgroundColor: '#477571',
+                    borderColor: '#3b5f5b',
                     borderWidth: 1
                 }]
             },

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -783,7 +783,7 @@ class HeritageStatistics {
                     <button class="legend-toggle" type="button">
                         <span class="legend-color" style="background:${color}"></span>
                         ${parent}
-                        <span class="legend-count" style="font-weight:400;color:var(--text-secondary);margin-left:2px">(${subs.length})</span>
+                        <span class="legend-count">(${subs.length})</span>
                         <span class="legend-chevron">&#9660;</span>
                     </button>
                     <div class="legend-subs">${subHTML}</div>

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -816,8 +816,8 @@ class HeritageStatistics {
                 datasets: [{
                     label: 'Families',
                     data: data,
-                    backgroundColor: '#24690a',
-                    borderColor: '#1a4f07',
+                    backgroundColor: '#477571',
+                    borderColor: '#3b5f5b',
                     borderWidth: 1
                 }]
             },
@@ -860,8 +860,8 @@ class HeritageStatistics {
                 datasets: [{
                     label: 'Families',
                     data: data,
-                    backgroundColor: '#24690a',
-                    borderColor: '#1a4f07',
+                    backgroundColor: '#154341',
+                    borderColor: '#0e2e2c',
                     borderWidth: 1
                 }]
             },

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -314,11 +314,14 @@ class HeritageStatistics {
             }))
             .sort((a, b) => b.total - a.total);
 
-        // Flatten to [{label, parent, count}]
+        // Flatten to [{label, parent, count, rank}]
+        // rank = position within the parent group (1 = largest sub-ethnicity)
         const result = [];
-        sorted.forEach(({ parent, subs }) =>
-            subs.forEach(([label, count]) => result.push({ label, parent, count }))
-        );
+        sorted.forEach(({ parent, subs }) => {
+            subs.forEach(([label, count], idx) =>
+                result.push({ label, parent, count, rank: idx + 1 })
+            );
+        });
         return result;
     }
 
@@ -342,69 +345,14 @@ class HeritageStatistics {
     }
 
     /**
-     * Convert a CSS hex colour to [h (0-360), s (0-100), l (0-100)].
-     * @param {string} hex - e.g. '#24690a'
-     * @returns {[number, number, number]}
-     */
-    _hexToHsl(hex) {
-        const r = parseInt(hex.slice(1, 3), 16) / 255;
-        const g = parseInt(hex.slice(3, 5), 16) / 255;
-        const b = parseInt(hex.slice(5, 7), 16) / 255;
-        const max = Math.max(r, g, b), min = Math.min(r, g, b);
-        let h = 0, s = 0;
-        const l = (max + min) / 2;
-        if (max !== min) {
-            const d = max - min;
-            s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-            switch (max) {
-                case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
-                case g: h = ((b - r) / d + 2) / 6; break;
-                case b: h = ((r - g) / d + 4) / 6; break;
-            }
-        }
-        return [h * 360, s * 100, l * 100];
-    }
-
-    /**
-     * Build colors for sub-ethnicity slices using hue rotation within each
-     * parent ethnicity family.  Rotating hue (rather than just varying lightness)
-     * keeps slices in the same colour family while remaining visually distinct
-     * even on very small wedges.
-     *
-     * @param {Array<{label,parent,count}>} items - output of getSubEthnicityDistribution()
-     * @returns {Array<string>} CSS colour strings, one per item
+     * Get colors for sub-ethnicity slices — each slice uses the same flat color
+     * as its parent ethnicity. Rank numbers drawn inside the slices distinguish
+     * sub-groups within the same color family.
+     * @param {Array<{label,parent,count,rank}>} items
+     * @returns {Array<string>}
      */
     getSubEthnicityColors(items) {
-        // How many sub-ethnicities does each parent have?
-        const parentTotals = {};
-        items.forEach(({ parent }) => {
-            parentTotals[parent] = (parentTotals[parent] || 0) + 1;
-        });
-
-        const parentIdx = {};
-        return items.map(({ parent }) => {
-            const total = parentTotals[parent];
-            const idx   = parentIdx[parent] ?? 0;
-            parentIdx[parent] = idx + 1;
-
-            const baseHex = HaplotypeConfig.getEthnicityColor(parent);
-            if (total === 1) return baseHex; // only one sub — use exact base colour
-
-            const [h, s, l] = this._hexToHsl(baseHex);
-
-            // Spread hue symmetrically around the base; cap total arc at 60°
-            // so even 7 Nogai sub-groups stay clearly in the same family.
-            const spread   = Math.min((total - 1) * 22, 60);
-            const hueShift = -spread / 2 + idx * (spread / (total - 1));
-            const newH     = ((h + hueShift) % 360 + 360) % 360;
-
-            // Vary lightness from slightly darker to slightly lighter
-            const lMin = Math.max(l - 12, 22);
-            const lMax = Math.min(l + 18, 70);
-            const newL = lMin + idx * (lMax - lMin) / (total - 1);
-
-            return `hsl(${newH.toFixed(1)}, ${s.toFixed(1)}%, ${newL.toFixed(1)}%)`;
-        });
+        return items.map(({ parent }) => HaplotypeConfig.getEthnicityColor(parent));
     }
 
     /**
@@ -745,16 +693,52 @@ class HeritageStatistics {
         if (!ctx) return;
 
         const items  = this.getSubEthnicityDistribution();
-        const labels = items.map(i => i.label);
+        // Legend label: "1. Kabardian", "2. Shapsough" etc.
+        const labels = items.map(i => `${i.rank}. ${i.label}`);
         const data   = items.map(i => i.count);
         const colors = this.getSubEthnicityColors(items);
+        // Store ranks in dataset for the inline label plugin
+        const ranks  = items.map(i => i.rank);
+
+        // Inline plugin: draw rank number in the middle of each arc.
+        // No external dependency — uses the Chart.js afterDatasetsDraw hook.
+        const rankLabelPlugin = {
+            id: 'subEthnicityRankLabels',
+            afterDatasetsDraw(chart) {
+                const { ctx: c, chartArea } = chart;
+                const meta = chart.getDatasetMeta(0);
+                const ds   = chart.data.datasets[0];
+                const total = ds.data.reduce((a, b) => a + b, 0);
+
+                meta.data.forEach((arc, index) => {
+                    // Skip slices narrower than ~8° — number won't fit
+                    const sliceAngle = arc.endAngle - arc.startAngle;
+                    if (sliceAngle < 0.14) return;
+
+                    const midAngle  = (arc.startAngle + arc.endAngle) / 2;
+                    const midRadius = (arc.innerRadius + arc.outerRadius) / 2;
+                    const x = arc.x + midRadius * Math.cos(midAngle);
+                    const y = arc.y + midRadius * Math.sin(midAngle);
+
+                    c.save();
+                    c.font        = 'bold 11px sans-serif';
+                    c.fillStyle   = '#ffffff';
+                    c.textAlign   = 'center';
+                    c.textBaseline = 'middle';
+                    c.fillText(ds.ranks[index], x, y);
+                    c.restore();
+                });
+            }
+        };
 
         this.charts.subEthnicity = new Chart(ctx, {
             type: 'doughnut',
+            plugins: [rankLabelPlugin],
             data: {
                 labels,
                 datasets: [{
                     data,
+                    ranks,   // consumed by rankLabelPlugin
                     backgroundColor: colors,
                     borderWidth: 2,
                     borderColor: '#fff'
@@ -771,7 +755,9 @@ class HeritageStatistics {
                     tooltip: {
                         callbacks: {
                             label: function(context) {
-                                const label = context.label || '';
+                                // Strip the rank prefix from the display label in tooltip
+                                const raw   = context.label || '';
+                                const label = raw.replace(/^\d+\.\s*/, '');
                                 const value = context.parsed || 0;
                                 const total = context.dataset.data.reduce((a, b) => a + b, 0);
                                 const pct   = ((value / total) * 100).toFixed(1);
@@ -964,9 +950,10 @@ class HeritageStatistics {
      */
     updateSubEthnicityChart() {
         const items = this.getSubEthnicityDistribution();
-        this.charts.subEthnicity.data.labels                          = items.map(i => i.label);
-        this.charts.subEthnicity.data.datasets[0].data                = items.map(i => i.count);
-        this.charts.subEthnicity.data.datasets[0].backgroundColor     = this.getSubEthnicityColors(items);
+        this.charts.subEthnicity.data.labels                      = items.map(i => `${i.rank}. ${i.label}`);
+        this.charts.subEthnicity.data.datasets[0].data             = items.map(i => i.count);
+        this.charts.subEthnicity.data.datasets[0].ranks            = items.map(i => i.rank);
+        this.charts.subEthnicity.data.datasets[0].backgroundColor  = this.getSubEthnicityColors(items);
         this.charts.subEthnicity.update();
     }
 

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -308,7 +308,9 @@ class HeritageStatistics {
         const groups = {};
 
         this.data.forEach(family => {
-            const parent = family.ethnicity?.main?.english || 'Unknown';
+            const parent = family.ethnicity?.main?.english ||
+                           family.ethnicity?.main?.native ||
+                           'Unknown';
             const sub    = family.ethnicity?.main?.sub?.english ||
                            family.ethnicity?.main?.sub?.native ||
                            parent; // fall back to parent label if no sub-group
@@ -345,6 +347,7 @@ class HeritageStatistics {
         this.data.forEach(family => {
             const state = family.location?.state?.main?.english ||
                           family.location?.state?.main?.russian ||
+                          family.location?.state?.main?.native ||
                           'Unknown';
             distribution[state] = (distribution[state] || 0) + 1;
         });
@@ -794,27 +797,32 @@ class HeritageStatistics {
             seen[item.parent].push(item);
         });
 
-        container.innerHTML = groups.map(({ parent, subs }) => {
+        container.innerHTML = groups.map(({ parent, subs }, i) => {
             const color      = HaplotypeConfig.getEthnicityColor(parent);
             const safeParent = this.escapeHtml(parent);
+            const subsId     = `sub-legend-subs-${i}`;
             const subHTML    = subs.map(s =>
                 `<div class="legend-sub-row">${s.rank} &ndash; ${this.escapeHtml(s.label)}</div>`
             ).join('');
             return `
                 <div class="legend-group">
-                    <button class="legend-toggle" type="button">
+                    <button class="legend-toggle" type="button"
+                            aria-expanded="false"
+                            aria-controls="${subsId}">
                         <span class="legend-color" style="background:${color}"></span>
                         ${safeParent}
                         <span class="legend-count">(${subs.length})</span>
                         <span class="legend-chevron">&#9660;</span>
                     </button>
-                    <div class="legend-subs">${subHTML}</div>
+                    <div class="legend-subs" id="${subsId}">${subHTML}</div>
                 </div>`;
         }).join('');
 
         // Attach toggle listeners
         container.querySelectorAll('.legend-toggle').forEach(btn => {
             btn.addEventListener('click', () => {
+                const expanded = btn.getAttribute('aria-expanded') === 'true';
+                btn.setAttribute('aria-expanded', String(!expanded));
                 btn.closest('.legend-group').classList.toggle('open');
             });
         });

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -778,15 +778,13 @@ class HeritageStatistics {
             const subHTML = subs.map(s =>
                 `<div class="legend-sub-row">${s.rank} &ndash; ${s.label}</div>`
             ).join('');
-            // Single sub-ethnicity = no toggle needed, just show inline
-            const hasMultiple = subs.length > 1;
             return `
-                <div class="legend-group${hasMultiple ? '' : ' open'}">
+                <div class="legend-group">
                     <button class="legend-toggle" type="button">
                         <span class="legend-color" style="background:${color}"></span>
                         ${parent}
                         <span class="legend-count" style="font-weight:400;color:var(--text-secondary);margin-left:2px">(${subs.length})</span>
-                        ${hasMultiple ? '<span class="legend-chevron">&#9660;</span>' : ''}
+                        <span class="legend-chevron">&#9660;</span>
                     </button>
                     <div class="legend-subs">${subHTML}</div>
                 </div>`;

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -71,7 +71,9 @@ class HeritageStatistics {
         this.createYSubcladeChart();
         this.createMtSubcladeChart();
         this.createEthnicityChart();
+        this.createSubEthnicityChart();
         this.createVillageChart();
+        this.createStateChart();
     }
 
     /**
@@ -83,7 +85,9 @@ class HeritageStatistics {
         if (this.charts.ySubclade) this.updateYSubcladeChart();
         if (this.charts.mtSubclade) this.updateMtSubcladeChart();
         if (this.charts.ethnicity) this.updateEthnicityChart();
+        if (this.charts.subEthnicity) this.updateSubEthnicityChart();
         if (this.charts.village) this.updateVillageChart();
+        if (this.charts.state) this.updateStateChart();
     }
 
     /**
@@ -282,6 +286,44 @@ class HeritageStatistics {
         });
         
         return distribution;
+    }
+
+    /**
+     * Get sub-ethnicity distribution
+     */
+    getSubEthnicityDistribution() {
+        const distribution = {};
+
+        this.data.forEach(family => {
+            const sub = family.ethnicity?.main?.sub?.english ||
+                        family.ethnicity?.main?.sub?.native ||
+                        family.ethnicity?.main?.english ||
+                        'Unknown';
+            distribution[sub] = (distribution[sub] || 0) + 1;
+        });
+
+        return Object.entries(distribution)
+            .sort((a, b) => b[1] - a[1])
+            .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
+    }
+
+    /**
+     * Get state distribution (top 10)
+     */
+    getStateDistribution() {
+        const distribution = {};
+
+        this.data.forEach(family => {
+            const state = family.location?.state?.main?.english ||
+                          family.location?.state?.main?.russian ||
+                          'Unknown';
+            distribution[state] = (distribution[state] || 0) + 1;
+        });
+
+        return Object.entries(distribution)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 10)
+            .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
     }
 
     /**
@@ -615,6 +657,56 @@ class HeritageStatistics {
     }
 
     /**
+     * Create Sub-Ethnicity Doughnut Chart
+     */
+    createSubEthnicityChart() {
+        const ctx = document.getElementById('subEthnicityChart');
+        if (!ctx) return;
+
+        const distribution = this.getSubEthnicityDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+        const colors = this.generateColors(labels.length);
+
+        this.charts.subEthnicity = new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: labels,
+                datasets: [{
+                    data: data,
+                    backgroundColor: colors,
+                    borderWidth: 2,
+                    borderColor: '#fff'
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {
+                    legend: {
+                        position: 'right',
+                        labels: {
+                            padding: 10,
+                            font: { size: 12 }
+                        }
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: function(context) {
+                                const label = context.label || '';
+                                const value = context.parsed || 0;
+                                const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                                const percentage = ((value / total) * 100).toFixed(1);
+                                return `${label}: ${value} (${percentage}%)`;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /**
      * Create Village Bar Chart (Top 10)
      */
     createVillageChart() {
@@ -653,6 +745,46 @@ class HeritageStatistics {
                     legend: {
                         display: false
                     }
+                }
+            }
+        });
+    }
+
+    /**
+     * Create State Bar Chart (Top 10)
+     */
+    createStateChart() {
+        const ctx = document.getElementById('stateChart');
+        if (!ctx) return;
+
+        const distribution = this.getStateDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+
+        this.charts.state = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Families',
+                    data: data,
+                    backgroundColor: '#24690a',
+                    borderColor: '#1a4f07',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                indexAxis: 'y',
+                responsive: true,
+                maintainAspectRatio: true,
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        ticks: { stepSize: 1 }
+                    }
+                },
+                plugins: {
+                    legend: { display: false }
                 }
             }
         });
@@ -750,6 +882,20 @@ class HeritageStatistics {
     }
 
     /**
+     * Update sub-ethnicity chart with new data
+     */
+    updateSubEthnicityChart() {
+        const distribution = this.getSubEthnicityDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+
+        this.charts.subEthnicity.data.labels = labels;
+        this.charts.subEthnicity.data.datasets[0].data = data;
+        this.charts.subEthnicity.data.datasets[0].backgroundColor = this.generateColors(labels.length);
+        this.charts.subEthnicity.update();
+    }
+
+    /**
      * Update village chart with new data
      */
     updateVillageChart() {
@@ -760,6 +906,19 @@ class HeritageStatistics {
         this.charts.village.data.labels = labels;
         this.charts.village.data.datasets[0].data = data;
         this.charts.village.update();
+    }
+
+    /**
+     * Update state chart with new data
+     */
+    updateStateChart() {
+        const distribution = this.getStateDistribution();
+        const labels = Object.keys(distribution);
+        const data = Object.values(distribution);
+
+        this.charts.state.data.labels = labels;
+        this.charts.state.data.datasets[0].data = data;
+        this.charts.state.update();
     }
 }
 

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -447,7 +447,7 @@ class HeritageStatistics {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: true,
+                maintainAspectRatio: false,
                 plugins: {
                     legend: {
                         position: 'right',
@@ -507,7 +507,7 @@ class HeritageStatistics {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: true,
+                maintainAspectRatio: false,
                 plugins: {
                     legend: {
                         position: 'right',
@@ -567,7 +567,7 @@ class HeritageStatistics {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: true,
+                maintainAspectRatio: false,
                 plugins: {
                     legend: {
                         position: 'right',
@@ -619,7 +619,7 @@ class HeritageStatistics {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: true,
+                maintainAspectRatio: false,
                 plugins: {
                     legend: {
                         position: 'right',
@@ -671,7 +671,7 @@ class HeritageStatistics {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: true,
+                maintainAspectRatio: false,
                 plugins: {
                     legend: {
                         position: 'right',
@@ -732,7 +732,7 @@ class HeritageStatistics {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: true,
+                maintainAspectRatio: false,
                 plugins: {
                     legend: { display: false },
                     tooltip: {
@@ -824,7 +824,7 @@ class HeritageStatistics {
             options: {
                 indexAxis: 'y', // Horizontal bar chart
                 responsive: true,
-                maintainAspectRatio: true,
+                maintainAspectRatio: false,
                 scales: {
                     x: {
                         beginAtZero: true,
@@ -868,7 +868,7 @@ class HeritageStatistics {
             options: {
                 indexAxis: 'y',
                 responsive: true,
-                maintainAspectRatio: true,
+                maintainAspectRatio: false,
                 scales: {
                     x: {
                         beginAtZero: true,

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -718,13 +718,23 @@ class HeritageStatistics {
                 const ds   = chart.data.datasets[0];
 
                 meta.data.forEach((arc, index) => {
-                    if (arc.endAngle - arc.startAngle < 0.14) return;
-                    const midAngle  = (arc.startAngle + arc.endAngle) / 2;
-                    const midRadius = (arc.innerRadius + arc.outerRadius) / 2;
+                    const spanAngle   = arc.endAngle - arc.startAngle;
+                    const ringThick   = arc.outerRadius - arc.innerRadius;
+                    const midRadius   = (arc.innerRadius + arc.outerRadius) / 2;
+                    // Arc chord length at mid-radius — limits label in tangential direction
+                    const arcLen      = spanAngle * midRadius;
+                    // Font size: fill ~55% of whichever dimension is tighter, clamped 8–15px
+                    const fontSize    = Math.round(
+                        Math.min(Math.max(Math.min(ringThick, arcLen) * 0.55, 8), 15)
+                    );
+                    // Skip slice if arc chord is too narrow to fit even one character
+                    if (arcLen < fontSize * 0.9) return;
+
+                    const midAngle = (arc.startAngle + arc.endAngle) / 2;
                     const x = arc.x + midRadius * Math.cos(midAngle);
                     const y = arc.y + midRadius * Math.sin(midAngle);
                     c.save();
-                    c.font = 'bold 11px sans-serif';
+                    c.font = `bold ${fontSize}px sans-serif`;
                     c.fillStyle = '#ffffff';
                     c.textAlign = 'center';
                     c.textBaseline = 'middle';

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -762,7 +762,7 @@ class HeritageStatistics {
         const container = document.getElementById('subEthnicityLegend');
         if (!container) return;
 
-        // Group items by parent in order they appear
+        // Group items by parent preserving order
         const groups = [];
         const seen   = {};
         items.forEach(item => {
@@ -774,19 +774,30 @@ class HeritageStatistics {
         });
 
         container.innerHTML = groups.map(({ parent, subs }) => {
-            const color = HaplotypeConfig.getEthnicityColor(parent);
-            const subRows = subs.map(s =>
-                `<div class="legend-sub">${s.rank} &ndash; ${s.label}</div>`
+            const color   = HaplotypeConfig.getEthnicityColor(parent);
+            const subHTML = subs.map(s =>
+                `<div class="legend-sub-row">${s.rank} &ndash; ${s.label}</div>`
             ).join('');
+            // Single sub-ethnicity = no toggle needed, just show inline
+            const hasMultiple = subs.length > 1;
             return `
-                <div class="legend-group">
-                    <div class="legend-parent">
+                <div class="legend-group${hasMultiple ? '' : ' open'}">
+                    <button class="legend-toggle" type="button">
                         <span class="legend-color" style="background:${color}"></span>
                         ${parent}
-                    </div>
-                    ${subRows}
+                        <span class="legend-count" style="font-weight:400;color:var(--text-secondary);margin-left:2px">(${subs.length})</span>
+                        ${hasMultiple ? '<span class="legend-chevron">&#9660;</span>' : ''}
+                    </button>
+                    <div class="legend-subs">${subHTML}</div>
                 </div>`;
         }).join('');
+
+        // Attach toggle listeners
+        container.querySelectorAll('.legend-toggle').forEach(btn => {
+            btn.addEventListener('click', () => {
+                btn.closest('.legend-group').classList.toggle('open');
+            });
+        });
     }
 
     /**

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -289,22 +289,37 @@ class HeritageStatistics {
     }
 
     /**
-     * Get sub-ethnicity distribution
+     * Get sub-ethnicity distribution grouped by parent ethnicity.
+     * Returns an array of {label, parent, count} sorted by parent total (desc)
+     * then by sub-ethnicity count (desc) within each group.
      */
     getSubEthnicityDistribution() {
-        const distribution = {};
+        const groups = {};
 
         this.data.forEach(family => {
-            const sub = family.ethnicity?.main?.sub?.english ||
-                        family.ethnicity?.main?.sub?.native ||
-                        family.ethnicity?.main?.english ||
-                        'Unknown';
-            distribution[sub] = (distribution[sub] || 0) + 1;
+            const parent = family.ethnicity?.main?.english || 'Unknown';
+            const sub    = family.ethnicity?.main?.sub?.english ||
+                           family.ethnicity?.main?.sub?.native ||
+                           parent; // fall back to parent label if no sub-group
+            if (!groups[parent]) groups[parent] = {};
+            groups[parent][sub] = (groups[parent][sub] || 0) + 1;
         });
 
-        return Object.entries(distribution)
-            .sort((a, b) => b[1] - a[1])
-            .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
+        // Sort parents by total count descending
+        const sorted = Object.entries(groups)
+            .map(([parent, subs]) => ({
+                parent,
+                total: Object.values(subs).reduce((a, b) => a + b, 0),
+                subs:  Object.entries(subs).sort((a, b) => b[1] - a[1])
+            }))
+            .sort((a, b) => b.total - a.total);
+
+        // Flatten to [{label, parent, count}]
+        const result = [];
+        sorted.forEach(({ parent, subs }) =>
+            subs.forEach(([label, count]) => result.push({ label, parent, count }))
+        );
+        return result;
     }
 
     /**
@@ -324,6 +339,72 @@ class HeritageStatistics {
             .sort((a, b) => b[1] - a[1])
             .slice(0, 10)
             .reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
+    }
+
+    /**
+     * Convert a CSS hex colour to [h (0-360), s (0-100), l (0-100)].
+     * @param {string} hex - e.g. '#24690a'
+     * @returns {[number, number, number]}
+     */
+    _hexToHsl(hex) {
+        const r = parseInt(hex.slice(1, 3), 16) / 255;
+        const g = parseInt(hex.slice(3, 5), 16) / 255;
+        const b = parseInt(hex.slice(5, 7), 16) / 255;
+        const max = Math.max(r, g, b), min = Math.min(r, g, b);
+        let h = 0, s = 0;
+        const l = (max + min) / 2;
+        if (max !== min) {
+            const d = max - min;
+            s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+            switch (max) {
+                case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
+                case g: h = ((b - r) / d + 2) / 6; break;
+                case b: h = ((r - g) / d + 4) / 6; break;
+            }
+        }
+        return [h * 360, s * 100, l * 100];
+    }
+
+    /**
+     * Build colors for sub-ethnicity slices using hue rotation within each
+     * parent ethnicity family.  Rotating hue (rather than just varying lightness)
+     * keeps slices in the same colour family while remaining visually distinct
+     * even on very small wedges.
+     *
+     * @param {Array<{label,parent,count}>} items - output of getSubEthnicityDistribution()
+     * @returns {Array<string>} CSS colour strings, one per item
+     */
+    getSubEthnicityColors(items) {
+        // How many sub-ethnicities does each parent have?
+        const parentTotals = {};
+        items.forEach(({ parent }) => {
+            parentTotals[parent] = (parentTotals[parent] || 0) + 1;
+        });
+
+        const parentIdx = {};
+        return items.map(({ parent }) => {
+            const total = parentTotals[parent];
+            const idx   = parentIdx[parent] ?? 0;
+            parentIdx[parent] = idx + 1;
+
+            const baseHex = HaplotypeConfig.getEthnicityColor(parent);
+            if (total === 1) return baseHex; // only one sub — use exact base colour
+
+            const [h, s, l] = this._hexToHsl(baseHex);
+
+            // Spread hue symmetrically around the base; cap total arc at 60°
+            // so even 7 Nogai sub-groups stay clearly in the same family.
+            const spread   = Math.min((total - 1) * 22, 60);
+            const hueShift = -spread / 2 + idx * (spread / (total - 1));
+            const newH     = ((h + hueShift) % 360 + 360) % 360;
+
+            // Vary lightness from slightly darker to slightly lighter
+            const lMin = Math.max(l - 12, 22);
+            const lMax = Math.min(l + 18, 70);
+            const newL = lMin + idx * (lMax - lMin) / (total - 1);
+
+            return `hsl(${newH.toFixed(1)}, ${s.toFixed(1)}%, ${newL.toFixed(1)}%)`;
+        });
     }
 
     /**
@@ -663,17 +744,17 @@ class HeritageStatistics {
         const ctx = document.getElementById('subEthnicityChart');
         if (!ctx) return;
 
-        const distribution = this.getSubEthnicityDistribution();
-        const labels = Object.keys(distribution);
-        const data = Object.values(distribution);
-        const colors = this.generateColors(labels.length);
+        const items  = this.getSubEthnicityDistribution();
+        const labels = items.map(i => i.label);
+        const data   = items.map(i => i.count);
+        const colors = this.getSubEthnicityColors(items);
 
         this.charts.subEthnicity = new Chart(ctx, {
             type: 'doughnut',
             data: {
-                labels: labels,
+                labels,
                 datasets: [{
-                    data: data,
+                    data,
                     backgroundColor: colors,
                     borderWidth: 2,
                     borderColor: '#fff'
@@ -685,10 +766,7 @@ class HeritageStatistics {
                 plugins: {
                     legend: {
                         position: 'right',
-                        labels: {
-                            padding: 10,
-                            font: { size: 12 }
-                        }
+                        labels: { padding: 10, font: { size: 12 } }
                     },
                     tooltip: {
                         callbacks: {
@@ -696,8 +774,8 @@ class HeritageStatistics {
                                 const label = context.label || '';
                                 const value = context.parsed || 0;
                                 const total = context.dataset.data.reduce((a, b) => a + b, 0);
-                                const percentage = ((value / total) * 100).toFixed(1);
-                                return `${label}: ${value} (${percentage}%)`;
+                                const pct   = ((value / total) * 100).toFixed(1);
+                                return `${label}: ${value} (${pct}%)`;
                             }
                         }
                     }
@@ -885,13 +963,10 @@ class HeritageStatistics {
      * Update sub-ethnicity chart with new data
      */
     updateSubEthnicityChart() {
-        const distribution = this.getSubEthnicityDistribution();
-        const labels = Object.keys(distribution);
-        const data = Object.values(distribution);
-
-        this.charts.subEthnicity.data.labels = labels;
-        this.charts.subEthnicity.data.datasets[0].data = data;
-        this.charts.subEthnicity.data.datasets[0].backgroundColor = this.generateColors(labels.length);
+        const items = this.getSubEthnicityDistribution();
+        this.charts.subEthnicity.data.labels                          = items.map(i => i.label);
+        this.charts.subEthnicity.data.datasets[0].data                = items.map(i => i.count);
+        this.charts.subEthnicity.data.datasets[0].backgroundColor     = this.getSubEthnicityColors(items);
         this.charts.subEthnicity.update();
     }
 

--- a/assets/js/statistics.js
+++ b/assets/js/statistics.js
@@ -11,6 +11,17 @@ class HeritageStatistics {
     }
 
     /**
+     * HTML escape utility — prevents XSS when inserting data-derived strings into innerHTML
+     * @param {string} text
+     * @returns {string}
+     */
+    escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text || '';
+        return div.innerHTML;
+    }
+
+    /**
      * Initialize statistics module
      * @param {Array} heritageData - The heritage data from main app
      */
@@ -774,15 +785,16 @@ class HeritageStatistics {
         });
 
         container.innerHTML = groups.map(({ parent, subs }) => {
-            const color   = HaplotypeConfig.getEthnicityColor(parent);
-            const subHTML = subs.map(s =>
-                `<div class="legend-sub-row">${s.rank} &ndash; ${s.label}</div>`
+            const color      = HaplotypeConfig.getEthnicityColor(parent);
+            const safeParent = this.escapeHtml(parent);
+            const subHTML    = subs.map(s =>
+                `<div class="legend-sub-row">${s.rank} &ndash; ${this.escapeHtml(s.label)}</div>`
             ).join('');
             return `
                 <div class="legend-group">
                     <button class="legend-toggle" type="button">
                         <span class="legend-color" style="background:${color}"></span>
-                        ${parent}
+                        ${safeParent}
                         <span class="legend-count">(${subs.length})</span>
                         <span class="legend-chevron">&#9660;</span>
                     </button>

--- a/index.html
+++ b/index.html
@@ -246,16 +246,16 @@
                         <canvas id="subEthnicityChart"></canvas>
                     </div>
 
-                    <!-- Village Distribution -->
-                    <div class="chart-card">
-                        <h3>Top 10 Villages</h3>
-                        <canvas id="villageChart"></canvas>
-                    </div>
-
                     <!-- State Distribution -->
                     <div class="chart-card">
                         <h3>Top 10 States</h3>
                         <canvas id="stateChart"></canvas>
+                    </div>
+
+                    <!-- Village Distribution -->
+                    <div class="chart-card">
+                        <h3>Top 10 Villages</h3>
+                        <canvas id="villageChart"></canvas>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -243,10 +243,8 @@
                     <!-- Sub-Ethnicity Distribution -->
                     <div class="chart-card">
                         <h3>Sub-Ethnicity Distribution</h3>
-                        <div class="sub-ethnicity-wrap">
-                            <canvas id="subEthnicityChart"></canvas>
-                            <div id="subEthnicityLegend" class="sub-ethnicity-legend"></div>
-                        </div>
+                        <canvas id="subEthnicityChart"></canvas>
+                        <div id="subEthnicityLegend" class="sub-ethnicity-legend"></div>
                     </div>
 
                     <!-- State Distribution -->

--- a/index.html
+++ b/index.html
@@ -239,11 +239,23 @@
                         <h3>Ethnicity Distribution</h3>
                         <canvas id="ethnicityChart"></canvas>
                     </div>
-                    
+
+                    <!-- Sub-Ethnicity Distribution -->
+                    <div class="chart-card">
+                        <h3>Sub-Ethnicity Distribution</h3>
+                        <canvas id="subEthnicityChart"></canvas>
+                    </div>
+
                     <!-- Village Distribution -->
                     <div class="chart-card">
                         <h3>Top 10 Villages</h3>
                         <canvas id="villageChart"></canvas>
+                    </div>
+
+                    <!-- State Distribution -->
+                    <div class="chart-card">
+                        <h3>Top 10 States</h3>
+                        <canvas id="stateChart"></canvas>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -39,14 +39,14 @@
     <link rel="icon" type="image/x-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏔️</text></svg>">
 
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Circassian DNA Heritage Feed">
+    <meta property="og:title" content="Circassian DNA">
     <meta property="og:description" content="Explore genetic lineage and ancestral connections of Circassian families">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://kabartay.github.io/circassiandna-heritage/">
 
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Circassian DNA Heritage Feed">
+    <meta name="twitter:title" content="Circassian DNA">
     <meta name="twitter:description" content="Explore genetic lineage and ancestral connections of Circassian families">
 </head>
 <body>
@@ -88,19 +88,19 @@
 
         <!-- Tab Navigation -->
         <nav class="tab-navigation" aria-label="Main Navigation">
-            <button class="tab-btn active" data-tab="feed">
+            <button class="tab-btn active" data-tab="feed" aria-label="Feed">
                 <span class="tab-icon">🔎</span>
                 <span class="tab-label">Feed</span>
             </button>
-            <button class="tab-btn" data-tab="maps">
+            <button class="tab-btn" data-tab="maps" aria-label="Maps">
                 <span class="tab-icon">🌍</span>
                 <span class="tab-label">Maps</span>
             </button>
-            <button class="tab-btn" data-tab="statistics">
+            <button class="tab-btn" data-tab="statistics" aria-label="Statistics">
                 <span class="tab-icon">📊</span>
                 <span class="tab-label">Statistics</span>
             </button>
-            <button class="tab-btn" data-tab="about">
+            <button class="tab-btn" data-tab="about" aria-label="About">
                 <span class="tab-icon">ℹ️</span>
                 <span class="tab-label">About</span>
             </button>

--- a/index.html
+++ b/index.html
@@ -243,8 +243,12 @@
                     <!-- Sub-Ethnicity Distribution -->
                     <div class="chart-card">
                         <h3>Sub-Ethnicity Distribution</h3>
-                        <canvas id="subEthnicityChart"></canvas>
-                        <div id="subEthnicityLegend" class="sub-ethnicity-legend"></div>
+                        <div class="sub-ethnicity-wrap">
+                            <div class="sub-ethnicity-chart-container">
+                                <canvas id="subEthnicityChart"></canvas>
+                            </div>
+                            <div id="subEthnicityLegend" class="sub-ethnicity-legend"></div>
+                        </div>
                     </div>
 
                     <!-- State Distribution -->

--- a/index.html
+++ b/index.html
@@ -243,7 +243,10 @@
                     <!-- Sub-Ethnicity Distribution -->
                     <div class="chart-card">
                         <h3>Sub-Ethnicity Distribution</h3>
-                        <canvas id="subEthnicityChart"></canvas>
+                        <div class="sub-ethnicity-wrap">
+                            <canvas id="subEthnicityChart"></canvas>
+                            <div id="subEthnicityLegend" class="sub-ethnicity-legend"></div>
+                        </div>
                     </div>
 
                     <!-- State Distribution -->

--- a/index.html
+++ b/index.html
@@ -211,33 +211,33 @@
                     <!-- Y-DNA Pie Chart -->
                     <div class="chart-card">
                         <h3>Y-DNA Haplogroups</h3>
-                        <canvas id="yDnaChart"></canvas>
+                        <div class="chart-canvas-wrap"><canvas id="yDnaChart"></canvas></div>
                         <div id="yDnaStats" class="chart-stats"></div>
                     </div>
                     
                     <!-- mtDNA Pie Chart -->
                     <div class="chart-card">
                         <h3>mtDNA Haplogroups</h3>
-                        <canvas id="mtDnaChart"></canvas>
+                        <div class="chart-canvas-wrap"><canvas id="mtDnaChart"></canvas></div>
                         <div id="mtDnaStats" class="chart-stats"></div>
                     </div>
                     
                     <!-- Y-DNA Subclade Pie Chart -->
                     <div class="chart-card">
                         <h3>Y-DNA Subclade Distribution</h3>
-                        <canvas id="ySubcladeChart"></canvas>
+                        <div class="chart-canvas-wrap"><canvas id="ySubcladeChart"></canvas></div>
                     </div>
                     
                     <!-- mtDNA Subclade Pie Chart -->
                     <div class="chart-card">
                         <h3>mtDNA Subclade Distribution</h3>
-                        <canvas id="mtSubcladeChart"></canvas>
+                        <div class="chart-canvas-wrap"><canvas id="mtSubcladeChart"></canvas></div>
                     </div>
                     
                     <!-- Ethnicity Distribution -->
                     <div class="chart-card">
                         <h3>Ethnicity Distribution</h3>
-                        <canvas id="ethnicityChart"></canvas>
+                        <div class="chart-canvas-wrap"><canvas id="ethnicityChart"></canvas></div>
                     </div>
 
                     <!-- Sub-Ethnicity Distribution -->
@@ -254,13 +254,13 @@
                     <!-- State Distribution -->
                     <div class="chart-card">
                         <h3>Top 10 States</h3>
-                        <canvas id="stateChart"></canvas>
+                        <div class="chart-canvas-wrap"><canvas id="stateChart"></canvas></div>
                     </div>
 
                     <!-- Village Distribution -->
                     <div class="chart-card">
                         <h3>Top 10 Villages</h3>
-                        <canvas id="villageChart"></canvas>
+                        <div class="chart-canvas-wrap"><canvas id="villageChart"></canvas></div>
                     </div>
                 </div>
             </div>

--- a/validate-heritage-data.py
+++ b/validate-heritage-data.py
@@ -107,11 +107,15 @@ REQUIRED_SCHEMA = {
         'root': (str, type(None)),
         'clade': (str, type(None)),
         'terminalSnp': (str, type(None))
-    }
+    },
+    'metadata': {
+        'lab': (str, type(None))
+    },
+    'urls': dict
 }
 
 # Optional fields that may not exist in all records
-OPTIONAL_FIELDS = ['lab', 'urls']
+OPTIONAL_FIELDS = ['metadata', 'urls']
 
 def check_schema(data, schema, path='', optional_fields=None):
     """Recursively check if data matches schema."""


### PR DESCRIPTION
# Sub-Ethnicity & State Distribution charts + accessibility, data, and mobile polish

## Summary

Adds two new statistics charts (Sub-Ethnicity Distribution and Top 10 States), polishes the sub-ethnicity legend UX, fixes every chart to render at a uniform 300 px height across all screen sizes, and addresses a full round of Copilot code-review comments across security, accessibility, data correctness, and dead CSS.

---

## New Features

### Sub-Ethnicity Distribution chart
- Doughnut chart showing all sub-ethnicities (e.g. Kabardian, Besleney, Abzakh…) grouped by parent ethnicity
- Slices are coloured with their parent ethnicity's flat colour; a per-parent index is passed to `getEthnicityColor` so unknown parents each receive a distinct generated colour instead of all collapsing to the same red
- Rank numbers (1, 2, 3…) are drawn in white at each arc midpoint via a custom `rankLabelPlugin`; font size is scaled proportionally to the arc's available space (clamped 8–15 px) so all numbers visually fill their slice symmetrically
- Custom collapsible HTML legend placed to the right of the donut, grouped under each parent heading with a colour swatch and child count
- All groups start collapsed; clicking the toggle expands/collapses with a rotating chevron; `aria-expanded` and `aria-controls` managed on each toggle button for screen readers
- Legend vertically centred relative to the chart via `align-items: center`

### Top 10 States chart
- Horizontal bar chart of the 10 states/countries with the most families
- Colour: `#477571` — teal matching the stats bar

### Top 10 Villages chart
- Colour: `#DCD3C3` — warm brown matching the page background

### Layout order
- Row 3: Ethnicity Distribution (left) | Sub-Ethnicity Distribution (right)
- Row 4: Top 10 States (left) | Top 10 Villages (right)

---

## Bug Fixes

### Uniform 300 px chart height on all viewports
All charts were different heights on narrow viewports:
- Subclade pie charts shrank because their large right-side legend consumed available vertical space
- Sub-Ethnicity chart shrank to ~200×200 because the 130 px legend column left only ~200 px for the canvas
- State/Village bar charts rendered at ~150 px (Chart.js default `aspectRatio: 2`)

**Fix:** wrapped all 7 chart canvases in a `.chart-canvas-wrap { position: relative; height: 300px }` div and set `maintainAspectRatio: false` on all 8 charts. `.sub-ethnicity-chart-container` also gained `position: relative` so Chart.js can correctly absolutely-position its canvas.

### Mobile sub-ethnicity legend
On screens ≤ 768 px the flex row (chart left, legend right) cramped the donut. Now stacks vertically (`flex-direction: column`) so the chart gets full card width; the legend scrolls at `max-height: 160px`.

### `[object Object]` in village map cluster popup
`createVillagePopup` was using haplogroup objects as dictionary keys. Fixed by extracting `.clade || .root` from the haplogroup object before using it as a string key.

---

## Security

### XSS prevention in `_renderSubEthnicityLegend`
`parent` and `s.label` (both from heritage JSON data) were interpolated directly into `innerHTML`. Added `escapeHtml()` to `HeritageStatistics` (same DOM-based implementation as `main.js`) and applied it to both values.

### XSS prevention in `renderLocationOptions`
`state` and `displayName` were interpolated directly into `innerHTML` template literals for both element content and `data-*` attributes. Applied `escapeHtml()` to both before insertion.

---

## Accessibility

- Added `aria-label` to all four tab navigation buttons (`Feed`, `Maps`, `Statistics`, `About`) so screen readers have an explicit accessible name when `.tab-label` is hidden via `display: none` on mobile
- Added `aria-expanded="false"` and `aria-controls="sub-legend-subs-{i}"` to sub-ethnicity legend toggle buttons; click handler toggles `aria-expanded` alongside the `.open` class; controlled `<div>` gets the matching `id`
- Updated `og:title` and `twitter:title` from `"Circassian DNA Heritage Feed"` to `"Circassian DNA"` to match the page `<title>` (prevents stale link-preview branding)

---

## Data Correctness

- `getSubEthnicityDistribution`: added `.native` fallback for parent ethnicity lookup to match `getEthnicityDistribution` behaviour — prevents native-only families from appearing under `Unknown`
- `getStateDistribution`: added `.native` fallback after `.russian`, consistent with `data-loader.js` state lookup
- `getSubEthnicityColors`: build a stable per-parent index map and pass it as the fallback index to `getEthnicityColor`, so unknown parent ethnicities each get a distinct generated colour
- `getSubEthnicityDistribution` JSDoc: corrected return type from `{label, parent, count}` to `{label, parent, count, rank}`

---

## Code Quality & Dead Code Removal

### `main.js`
- Dropdown outside-click handler stored as `this._dropdownClickHandler`; previous listener removed before re-registering — prevents duplicate listeners if `initializeEthnicityDropdown` is ever re-called
- `updateLocationDisplayText`: mobile abbreviation mapping now applied to selected-state display text (was only applied when rendering option rows, not the closed-dropdown summary)

### `mobile.css`
- Dead `.chart-container` / `.chart-container canvas` rules retargeted to `.chart-canvas-wrap` (the actual markup class); removed unused `scale(0.90)` transform and `margin-bottom: -20px`
- Dead `.dropdown-menu` / `.ethnicity-options` dropdown sizing rules retargeted to `.custom-options` (the actual class rendered by `main.js`)
- Dead `.ethnicity-option` / `.ethnicity-flag` / `.ethnicity-name` layout rules retargeted to `.custom-option` / `.option-flag` / `.option-text`

### `styles.css`
- Added WCAG contrast ratio comments to `.tree-group` button rules: `#90EE90`/`#2c3e50` ≈ 7.1:1 and `#ADD8E6`/`#2c3e50` ≈ 6.8:1 (both pass WCAG AA)

### `validate-heritage-data.py`
- Fixed schema: `lab` is nested under `metadata.lab`, not a top-level optional field; `urls` remains top-level; `OPTIONAL_FIELDS` updated to `['metadata', 'urls']`

---

## Files Changed

| File | Net change | Key additions |
|---|---|---|
| `assets/js/statistics.js` | +304 lines | `getSubEthnicityDistribution`, `getStateDistribution`, `getSubEthnicityColors`, `_renderSubEthnicityLegend`, `createSubEthnicityChart` (with `rankLabelPlugin`), `createStateChart`, `escapeHtml`, all update methods; `maintainAspectRatio: false`; arc-proportional rank label font; aria attributes; data `.native` fallbacks |
| `assets/css/styles.css` | +120 lines | `.chart-canvas-wrap`, `.sub-ethnicity-wrap`, `.sub-ethnicity-chart-container` (with `position: relative`), full legend token/chevron/count/subs rules; mobile full-width grid; vertical sub-ethnicity stack; WCAG comments |
| `index.html` | +43 lines | `.chart-canvas-wrap` on all 7 canvases; sub-ethnicity card with explicit flex container; States before Villages; `aria-label` on tab buttons; updated OG/Twitter meta |
| `assets/js/main.js` | +27 lines | `escapeHtml` in `renderLocationOptions`; mobile abbrev in `updateLocationDisplayText`; named dropdown listener ref |
| `assets/css/mobile.css` | +25 lines | Dead selector fixes (chart container, dropdown, ethnicity option) |
| `validate-heritage-data.py` | +8 lines | `metadata.lab` nesting fix in validation schema |
