### PR TITLE
fix/mobile overlap filters

### DIFF
--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -297,6 +297,11 @@
         transition: all 0.2s ease !important;
     }
 
+    /* Indent sub-options to visually sit under their parent */
+    .custom-option.sub-option.visible {
+        padding-left: 44px !important;
+    }
+
     /* Keep hidden sub-options hidden on mobile */
     .custom-option.sub-option:not(.visible) {
         display: none !important;

--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -123,8 +123,8 @@
         position: relative;
     }
 
-    /* Keep open panel on top of sibling dropdowns below it */
-    .custom-dropdown:has(.custom-options.active) {
+    /* Boost open panel above sibling dropdowns below it */
+    .custom-options.active {
         z-index: 200;
     }
     

--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -286,7 +286,8 @@
         display: flex !important;
     }
     
-    .custom-option {
+    .custom-option:not(.sub-option),
+    .custom-option.sub-option.visible {
         display: flex !important;
         align-items: center !important;
         gap: 12px !important;
@@ -294,6 +295,11 @@
         min-height: 52px !important;
         border-radius: 12px !important;
         transition: all 0.2s ease !important;
+    }
+
+    /* Keep hidden sub-options hidden on mobile */
+    .custom-option.sub-option:not(.visible) {
+        display: none !important;
     }
     
     .custom-option:hover,

--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -277,9 +277,13 @@
     
     /* Ethnicity options — actual rendered classes from main.js */
     .custom-options {
-        display: flex !important;
         flex-direction: column !important;
         gap: 4px !important;
+    }
+
+    /* Only switch to flex when the panel is actually open */
+    .custom-options.active {
+        display: flex !important;
     }
     
     .custom-option {

--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -120,6 +120,12 @@
         width: 100% !important;
         min-width: 100% !important;
         max-width: 100% !important;
+        position: relative;
+    }
+
+    /* Keep open panel on top of sibling dropdowns below it */
+    .custom-dropdown:has(.custom-options.active) {
+        z-index: 200;
     }
     
     .custom-select,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -206,14 +206,10 @@ class HeritageApp {
      * Close all custom filter dropdowns
      */
     closeAllDropdowns() {
-        ['ethnicitySelect', 'locationSelect', 'cladeSelect'].forEach(id => {
-            const sel = document.getElementById(id);
-            if (sel) sel.classList.remove('active');
-        });
-        ['ethnicityOptions', 'locationOptions', 'cladeOptions'].forEach(id => {
-            const opts = document.getElementById(id);
-            if (opts) opts.classList.remove('active');
-        });
+        const container = document.querySelector('.filter-dropdowns');
+        if (!container) return;
+        container.querySelectorAll('.custom-select').forEach(el => el.classList.remove('active'));
+        container.querySelectorAll('.custom-options').forEach(el => el.classList.remove('active'));
     }
 
     /**

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -306,18 +306,51 @@ class HeritageApp {
             checkbox.addEventListener('click', (e) => {
                 e.stopPropagation();
                 const ethnicity = checkbox.dataset.ethnicity;
-                
+                const isMain = checkbox.dataset.type === 'main';
+
                 if (checkbox.checked) {
                     if (!this.selectedEthnicities.includes(ethnicity)) {
                         this.selectedEthnicities.push(ethnicity);
                     }
+                    // Cascade: check + show all sub-options for this main ethnicity
+                    if (isMain) {
+                        const mainOption = customOptions.querySelector(`.main-option[data-value="${ethnicity}"]`);
+                        if (mainOption && !mainOption.classList.contains('expanded')) {
+                            mainOption.classList.add('expanded');
+                        }
+                        customOptions.querySelectorAll(`.sub-option[data-parent="${ethnicity}"]`).forEach(sub => {
+                            sub.classList.add('visible');
+                            const subCb = sub.querySelector('.ethnicity-checkbox');
+                            if (subCb && !subCb.checked) {
+                                subCb.checked = true;
+                                const subVal = subCb.dataset.ethnicity;
+                                if (!this.selectedEthnicities.includes(subVal)) {
+                                    this.selectedEthnicities.push(subVal);
+                                }
+                            }
+                        });
+                    }
                 } else {
                     this.selectedEthnicities = this.selectedEthnicities.filter(e => e !== ethnicity);
+                    // Cascade: uncheck + collapse all sub-options for this main ethnicity
+                    if (isMain) {
+                        const mainOption = customOptions.querySelector(`.main-option[data-value="${ethnicity}"]`);
+                        if (mainOption) mainOption.classList.remove('expanded');
+                        customOptions.querySelectorAll(`.sub-option[data-parent="${ethnicity}"]`).forEach(sub => {
+                            sub.classList.remove('visible');
+                            const subCb = sub.querySelector('.ethnicity-checkbox');
+                            if (subCb && subCb.checked) {
+                                subCb.checked = false;
+                                const subVal = subCb.dataset.ethnicity;
+                                this.selectedEthnicities = this.selectedEthnicities.filter(e => e !== subVal);
+                            }
+                        });
+                    }
                 }
-                
+
                 // Update display text
                 this.updateEthnicityDisplayText();
-                
+
                 // Apply filters
                 this.applyFilters();
             });

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -198,7 +198,12 @@ class HeritageApp {
         if (this._globalDropdownHandler) {
             document.removeEventListener('click', this._globalDropdownHandler);
         }
-        this._globalDropdownHandler = () => this.closeAllDropdowns();
+        this._globalDropdownHandler = (e) => {
+            // Only close dropdowns if the click is outside any .custom-dropdown element
+            if (!e.target.closest('.custom-dropdown')) {
+                this.closeAllDropdowns();
+            }
+        };
         document.addEventListener('click', this._globalDropdownHandler);
     }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -193,8 +193,29 @@ class HeritageApp {
         this.initializeCladeDropdown(filterData.yClades, filterData.mtClades);
         
         console.log('✅ Filter dropdowns initialized');
+
+        // Single shared handler: close all dropdowns when clicking outside any of them
+        if (this._globalDropdownHandler) {
+            document.removeEventListener('click', this._globalDropdownHandler);
+        }
+        this._globalDropdownHandler = () => this.closeAllDropdowns();
+        document.addEventListener('click', this._globalDropdownHandler);
     }
-    
+
+    /**
+     * Close all custom filter dropdowns
+     */
+    closeAllDropdowns() {
+        ['ethnicitySelect', 'locationSelect', 'cladeSelect'].forEach(id => {
+            const sel = document.getElementById(id);
+            if (sel) sel.classList.remove('active');
+        });
+        ['ethnicityOptions', 'locationOptions', 'cladeOptions'].forEach(id => {
+            const opts = document.getElementById(id);
+            if (opts) opts.classList.remove('active');
+        });
+    }
+
     /**
      * Initialize custom ethnicity dropdown with flag images
      */
@@ -246,13 +267,17 @@ class HeritageApp {
         
         customOptions.innerHTML = optionsHTML;
         
-        // Toggle dropdown
+        // Toggle dropdown — close all others first
         customSelect.addEventListener('click', (e) => {
             e.stopPropagation();
-            customSelect.classList.toggle('active');
-            customOptions.classList.toggle('active');
+            const isOpen = customSelect.classList.contains('active');
+            this.closeAllDropdowns();
+            if (!isOpen) {
+                customSelect.classList.add('active');
+                customOptions.classList.add('active');
+            }
         });
-        
+
         // Handle reset option
         const resetOption = customOptions.querySelector('.reset-option');
         if (resetOption) {
@@ -352,17 +377,8 @@ class HeritageApp {
             });
         });
         
-        // Close dropdown when clicking outside — store reference to avoid duplicate listeners
-        if (this._dropdownClickHandler) {
-            document.removeEventListener('click', this._dropdownClickHandler);
-        }
-        this._dropdownClickHandler = () => {
-            customSelect.classList.remove('active');
-            customOptions.classList.remove('active');
-        };
-        document.addEventListener('click', this._dropdownClickHandler);
     }
-    
+
     /**
      * Update ethnicity display text based on selections
      */
@@ -430,13 +446,17 @@ class HeritageApp {
         optionsHTML += '</div>';
         customOptions.innerHTML = optionsHTML;
         
-        // Toggle dropdown
+        // Toggle dropdown — close all others first
         customSelect.addEventListener('click', (e) => {
             e.stopPropagation();
-            customSelect.classList.toggle('active');
-            customOptions.classList.toggle('active');
+            const isOpen = customSelect.classList.contains('active');
+            this.closeAllDropdowns();
+            if (!isOpen) {
+                customSelect.classList.add('active');
+                customOptions.classList.add('active');
+            }
         });
-        
+
         // Handle reset option
         const resetOption = customOptions.querySelector('.reset-option');
         if (resetOption) {
@@ -497,13 +517,8 @@ class HeritageApp {
             });
         });
         
-        // Close dropdown when clicking outside
-        document.addEventListener('click', () => {
-            customSelect.classList.remove('active');
-            customOptions.classList.remove('active');
-        });
     }
-    
+
     /**
      * Update clade display text based on selections
      */
@@ -559,20 +574,18 @@ class HeritageApp {
         // Initial render with all villages
         this.renderLocationOptions(customOptions, states, allVillages);
         
-        // Toggle dropdown
+        // Toggle dropdown — close all others first
         customSelect.addEventListener('click', (e) => {
             e.stopPropagation();
-            customSelect.classList.toggle('active');
-            customOptions.classList.toggle('active');
-        });
-        
-        // Close dropdown when clicking outside
-        document.addEventListener('click', () => {
-            customSelect.classList.remove('active');
-            customOptions.classList.remove('active');
+            const isOpen = customSelect.classList.contains('active');
+            this.closeAllDropdowns();
+            if (!isOpen) {
+                customSelect.classList.add('active');
+                customOptions.classList.add('active');
+            }
         });
     }
-    
+
     /**
      * Render location dropdown options with checkboxes
      */


### PR DESCRIPTION
## Fix: Mobile Filter Dropdown UX

### Problem

Three separate issues were found with filter dropdowns on Android mobile:

1. **All three panels open simultaneously on load** — all filter panels (Ethnicities, Location, Clades) were visible at the same time without any user interaction
2. **Opening one dropdown didn't close the others** — tapping a second dropdown stacked it on top of the first instead of replacing it
3. **Ethnicity sub-options always visible** — sub-ethnicities (e.g. Abdzakh, Kabardian) were permanently shown instead of being hidden under their parent
4. **No cascade on parent check** — checking a main ethnicity (e.g. Circassian) did not auto-check/expand its sub-ethnicities, and unchecking did not collapse/uncheck them
5. **Sub-options not indented on mobile** — sub-ethnicities appeared at the same left edge as their parent, unlike the desktop layout

---

### Root Causes

| # | File | Root cause |
|---|---|---|
| 1, 3 | `mobile.css` | `.custom-options { display: flex !important }` overrode `display: none` in `styles.css`, forcing all panels open permanently |
| 3 | `mobile.css` | `.custom-option { display: flex !important }` overrode `display: none` on `.sub-option`, showing all sub-options at all times |
| 2 | `main.js` | Each dropdown only toggled itself; no mechanism to close others when a new one opened |
| 4 | `main.js` | Checkbox handler only updated the clicked item; no cascade to sub-options |
| 5 | `mobile.css` | `padding: 12px 14px !important` on all `.custom-option` overrode the `padding-left: 44px` indent from `styles.css` |

---

### Changes

#### `assets/js/main.js`
- Added `closeAllDropdowns()` helper — removes `active` from all three select buttons and panels at once
- Each dropdown toggle now calls `closeAllDropdowns()` before opening itself, so only one panel is ever visible at a time
- Replaced three separate `document.addEventListener('click')` handlers (one per dropdown) with a single shared `_globalDropdownHandler`, deduped on re-init
- Checking a main ethnicity now auto-checks all its sub-options, pushes them to `selectedEthnicities`, and expands the group
- Unchecking a main ethnicity now auto-unchecks and removes all its subs from `selectedEthnicities`, and collapses the group

#### `assets/css/mobile.css`
- Moved `display: flex` from `.custom-options` to `.custom-options.active` only — panels are hidden by default
- Scoped `.custom-option { display: flex !important }` to `.custom-option:not(.sub-option)` and `.custom-option.sub-option.visible` only
- Added explicit `display: none !important` for `.sub-option:not(.visible)` to ensure hidden subs stay hidden
- Added `padding-left: 44px !important` on `.sub-option.visible` to restore indentation on mobile, matching desktop layout
- Added `position: relative` on `.custom-dropdown` and a `z-index` boost via `:has(.custom-options.active)` so the open panel always sits above siblings below it

---

### Before / After

| | Before | After |
|---|---|---|
| On load | All 3 panels visible | All panels hidden |
| Tap second dropdown | Both panels open | First closes, second opens |
| Tap outside | Only current panel closes | All panels close |
| Check main ethnicity | Only parent checked | Parent + all subs checked and expanded |
| Uncheck main ethnicity | Only parent unchecked | Parent + all subs unchecked and collapsed |
| Sub-option indent | Flush-left with parent | Indented 44px, matching desktop |